### PR TITLE
Fix worker leak, crash handling, and error-path robustness (v0.6.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AgentREPL"
 uuid = "c6b0b931-bd15-49f6-a31f-cf7d80eb5e81"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Samuel Talkington <talkington@pm.me>"]
 
 [deps]

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -174,7 +174,7 @@ Returns the log file path if logging is enabled.
 function setup_log_viewer!(; mode::Symbol=:auto, log_path::Union{String,Nothing}=nothing)
     # Close existing log if open
     if LOG_VIEWER.log_io !== nothing
-        close(LOG_VIEWER.log_io)
+        try; close(LOG_VIEWER.log_io); catch; end
         LOG_VIEWER.log_io = nothing
     end
 
@@ -285,10 +285,13 @@ Close the log viewer and clean up.
 """
 function close_log_viewer!()
     if LOG_VIEWER.log_io !== nothing
-        println(LOG_VIEWER.log_io, "\n", "="^60)
-        println(LOG_VIEWER.log_io, "Session ended - $(Dates.now())")
-        println(LOG_VIEWER.log_io, "="^60)
-        close(LOG_VIEWER.log_io)
+        try
+            println(LOG_VIEWER.log_io, "\n", "="^60)
+            println(LOG_VIEWER.log_io, "Session ended - $(Dates.now())")
+            println(LOG_VIEWER.log_io, "="^60)
+            close(LOG_VIEWER.log_io)
+        catch
+        end
         LOG_VIEWER.log_io = nothing
     end
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -472,8 +472,8 @@ The log file is written to ~/.julia/logs/repl.log by default.
             ToolParameter(
                 name = "mode",
                 type = "string",
-                description = "Viewer mode: 'auto', 'tmux', 'file', or 'off'",
-                required = true
+                description = "Viewer mode: 'auto' (default), 'tmux', 'file', or 'off'",
+                required = false
             )
         ],
         handler = params -> begin

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -21,10 +21,8 @@ is no longer in `workers()`).
 function _handle_worker_crash!(session::SessionState, e)
     if e isa Distributed.ProcessExitedException
         _clear_worker_state!(session)
-    elseif e isa Distributed.RemoteException
-        if session.worker_id !== nothing && !(session.worker_id in workers())
-            _clear_worker_state!(session)
-        end
+    elseif session.worker_id !== nothing && !(session.worker_id in workers())
+        _clear_worker_state!(session)
     end
 end
 
@@ -58,8 +56,9 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
             remotecall_fetch(Core.eval, session.worker_id, Main, :(using Pkg))
         catch e
             @warn "Failed to load Pkg on worker, killing half-initialized worker" session=session.name exception=(e, catch_backtrace())
+            orphan_id = session.worker_id
             _clear_worker_state!(session)
-            try; rmprocs(session.worker_id); catch; end
+            try; rmprocs(orphan_id); catch; end
             rethrow()
         end
 
@@ -224,14 +223,10 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
             try
                 value_str, output, error_str = remotecall_fetch(Core.eval, worker_id, Main, eval_expr)
             catch e
-                if e isa Distributed.ProcessExitedException
-                    _handle_worker_crash!(session, e)
-                    value_str = "nothing"
-                    output = ""
-                    error_str = "Worker process crashed. It will respawn on next eval. Error: $(sprint(showerror, e))"
-                else
-                    rethrow()
-                end
+                _handle_worker_crash!(session, e)
+                value_str = "nothing"
+                output = ""
+                error_str = sprint(showerror, e)
             end
         else
             # With timeout: race remotecall against a cancellable Timer
@@ -247,12 +242,11 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
             @async begin
                 try
                     result = fetch(future)
-                    put!(result_channel, (:ok, result))
+                    isopen(result_channel) && put!(result_channel, (:ok, result))
                 catch e
                     try
-                        put!(result_channel, (:error, e))
-                    catch put_err
-                        @warn "Failed to report async eval error (channel may be closed)" exception=(e, catch_backtrace())
+                        isopen(result_channel) && put!(result_channel, (:error, e))
+                    catch
                     end
                 end
             end


### PR DESCRIPTION
## Summary

Patch release fixing bugs found by automated review agents after v0.6.0:

- **Worker process leak**: `_clear_worker_state!` nulled `worker_id` before `rmprocs` could use it — orphaned workers accumulated over time
- **Crash handler gap**: `_handle_worker_crash!` only recognized 2 exception types, silently ignoring others and leaving stale worker IDs
- **Eval error asymmetry**: No-timeout path rethrew `RemoteException` past the formatting layer (timeout path handled it correctly)
- **atexit chain breakage**: `close_log_viewer!` wrote to potentially-closed IO without protection, aborting cleanup
- **Spurious timeout warnings**: Orphaned `@async` task produced `@warn` on every timeout
- **Schema inconsistency**: `log_viewer` tool had `required=true` on mode but handler used a default
- **Log viewer setup**: Unprotected `close()` on already-closed IO handle

## Test plan

- [x] All 197 tests pass
- [x] Spurious `@warn` on timeout is gone (verified in test output)
- [x] `close_log_viewer!()` safe on: nil state, double-close, pre-closed IO handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)