### PR TITLE
Add eval timing sparklines to info() output (closes #9)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AgentREPL"
 uuid = "c6b0b931-bd15-49f6-a31f-cf7d80eb5e81"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Samuel Talkington <talkington@pm.me>"]
 
 [deps]

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -1,4 +1,19 @@
-# formatting.jl - Result formatting and stacktrace truncation
+# formatting.jl - Result formatting, sparklines, and stacktrace truncation
+
+const SPARKLINE_BLOCKS = ['▁','▂','▃','▄','▅','▆','▇','█']
+
+"""
+    sparkline(values::AbstractVector{<:Real}) -> String
+
+Render a sparkline using Unicode block characters (▁▂▃▄▅▆▇█).
+"""
+function sparkline(values::AbstractVector{<:Real})
+    isempty(values) && return ""
+    lo, hi = extrema(values)
+    span = hi - lo
+    span == 0 && return repeat("▄", length(values))
+    return String([SPARKLINE_BLOCKS[clamp(round(Int, (v - lo) / span * 7) + 1, 1, 8)] for v in values])
+end
 
 """
     truncate_output(text::String, max_chars::Int; use_ansi::Bool=false) -> String

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -1,4 +1,4 @@
-# formatting.jl - Result formatting, sparklines, and stacktrace truncation
+# formatting.jl - Result formatting and stacktrace truncation
 
 const SPARKLINE_BLOCKS = ['▁','▂','▃','▄','▅','▆','▇','█']
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -240,6 +240,17 @@ Returns:
                     join(lines, "\n")
                 end
 
+                timings_str = if isempty(session.eval_timings)
+                    ""
+                else
+                    n = length(session.eval_timings)
+                    sorted = sort(session.eval_timings)
+                    med = sorted[div(n + 1, 2)]
+                    mx = maximum(session.eval_timings)
+                    spark = sparkline(session.eval_timings)
+                    "Eval Timings ($n evals): $spark  median $(format_elapsed(med)), max $(format_elapsed(mx))\n"
+                end
+
                 msg = """
 Session: $(session.name)$(session.name == SESSIONS.current ? " (current)" : "")
 Julia Version: $(info.version)
@@ -249,7 +260,7 @@ User Variables:
 $vars_str
 Loaded Modules: $(info.modules)
 Worker ID: $(session.worker_id)
-"""
+$(timings_str)"""
                 TextContent(text = msg)
             catch e
                 e isa InterruptException && rethrow()

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -245,8 +245,9 @@ Returns:
                 else
                     n = length(session.eval_timings)
                     sorted = sort(session.eval_timings)
-                    med = sorted[div(n + 1, 2)]
-                    mx = maximum(session.eval_timings)
+                    mid = div(n, 2)
+                    med = isodd(n) ? sorted[mid + 1] : (sorted[mid] + sorted[mid + 1]) / 2
+                    mx = sorted[end]
                     spark = sparkline(session.eval_timings)
                     "Eval Timings ($n evals): $spark  median $(format_elapsed(med)), max $(format_elapsed(mx))\n"
                 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -13,6 +13,7 @@ project environment, and Revise.jl tracking state.
 - `revise_loaded::Bool`: Whether Revise.jl was successfully loaded on the worker
 - `created_at::Float64`: Session creation time (from `time()`)
 - `last_used::Float64`: Last time this session was used (from `time()`)
+- `eval_timings::Vector{Float64}`: Ring buffer of recent eval durations (capped at 50)
 """
 mutable struct SessionState
     const name::String
@@ -21,11 +22,12 @@ mutable struct SessionState
     revise_loaded::Bool
     created_at::Float64
     last_used::Float64
+    eval_timings::Vector{Float64}
 
     function SessionState(name::String, worker_id::Union{Int,Nothing}, project_path::Union{String,Nothing}, revise_loaded::Bool=false)
         isempty(name) && error("Session name must not be empty")
         now = time()
-        new(name, worker_id, project_path, revise_loaded, now, now)
+        new(name, worker_id, project_path, revise_loaded, now, now, Float64[])
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -13,7 +13,7 @@ project environment, and Revise.jl tracking state.
 - `revise_loaded::Bool`: Whether Revise.jl was successfully loaded on the worker
 - `created_at::Float64`: Session creation time (from `time()`)
 - `last_used::Float64`: Last time this session was used (from `time()`)
-- `eval_timings::Vector{Float64}`: Ring buffer of recent eval durations (capped at 50)
+- `eval_timings::Vector{Float64}`: Ring buffer of recent eval durations (capped at `MAX_EVAL_TIMINGS`)
 """
 mutable struct SessionState
     const name::String
@@ -30,6 +30,8 @@ mutable struct SessionState
         new(name, worker_id, project_path, revise_loaded, now, now, Float64[])
     end
 end
+
+const MAX_EVAL_TIMINGS = 50
 
 """
     SessionRegistry

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -273,7 +273,7 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
     end
 
     push!(session.eval_timings, elapsed)
-    length(session.eval_timings) > 50 && popfirst!(session.eval_timings)
+    length(session.eval_timings) > MAX_EVAL_TIMINGS && popfirst!(session.eval_timings)
 
     return (value_str, output, error_str, elapsed)
 end

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -9,6 +9,7 @@ Clear worker-related fields on a session. Centralizes the paired reset of
 function _clear_worker_state!(session::SessionState)
     session.worker_id = nothing
     session.revise_loaded = false
+    empty!(session.eval_timings)
 end
 
 """
@@ -270,6 +271,9 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
             end
         end
     end
+
+    push!(session.eval_timings, elapsed)
+    length(session.eval_timings) > 50 && popfirst!(session.eval_timings)
 
     return (value_str, output, error_str, elapsed)
 end

--- a/test/test_e2e_agent.sh
+++ b/test/test_e2e_agent.sh
@@ -97,6 +97,11 @@ run_test "revise-status" \
     "Use the Julia revise tool with action 'status' and tell me whether Revise.jl is loaded." \
     "Revise|revise|loaded|available"
 
+# Test 8: eval timing sparkline in info
+run_test "info-sparkline" \
+    "Use the Julia eval tool three times: eval 1+1, eval 2+2, eval 3+3. Then call the info tool. Show me the full info output including eval timings." \
+    "Eval Timings|timings|▁|▂|▃|▄|▅|▆|▇|█|median|max"
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
 

--- a/test/test_eval.jl
+++ b/test/test_eval.jl
@@ -451,18 +451,17 @@ end
         @test all(t -> t > 0, session.eval_timings)
     end
 
-    @testset "eval_timings cap at 50" begin
+    @testset "eval_timings cap at MAX_EVAL_TIMINGS" begin
         session = AgentREPL.get_current_session!()
         empty!(session.eval_timings)
-        for i in 1:55
-            push!(session.eval_timings, Float64(i))
-        end
-        # Simulate the cap logic from capture_eval_on_worker
-        while length(session.eval_timings) > 50
-            popfirst!(session.eval_timings)
-        end
-        @test length(session.eval_timings) == 50
-        @test session.eval_timings[1] == 6.0  # first 5 were popped
+        # Pre-fill to just under cap
+        append!(session.eval_timings, fill(0.001, AgentREPL.MAX_EVAL_TIMINGS - 1))
+        # One real eval brings it to exactly MAX
+        AgentREPL.capture_eval_on_worker("1+1")
+        @test length(session.eval_timings) == AgentREPL.MAX_EVAL_TIMINGS
+        # Another real eval should evict the oldest pre-filled entry
+        AgentREPL.capture_eval_on_worker("2+2")
+        @test length(session.eval_timings) == AgentREPL.MAX_EVAL_TIMINGS
     end
 
     @testset "reset clears timings" begin

--- a/test/test_eval.jl
+++ b/test/test_eval.jl
@@ -430,6 +430,50 @@ end
     end
 end
 
+@testset "Sparkline" begin
+    @testset "sparkline rendering" begin
+        @test AgentREPL.sparkline(Float64[]) == ""
+        @test AgentREPL.sparkline([1.0, 1.0, 1.0]) == "▄▄▄"
+        result = AgentREPL.sparkline([0.0, 0.5, 1.0])
+        chars = collect(result)
+        @test length(chars) == 3
+        @test chars[1] == '▁'  # min
+        @test chars[3] == '█'  # max
+    end
+
+    @testset "eval_timings accumulation" begin
+        session = AgentREPL.get_current_session!()
+        empty!(session.eval_timings)
+        AgentREPL.capture_eval_on_worker("1+1")
+        AgentREPL.capture_eval_on_worker("2+2")
+        AgentREPL.capture_eval_on_worker("3+3")
+        @test length(session.eval_timings) == 3
+        @test all(t -> t > 0, session.eval_timings)
+    end
+
+    @testset "eval_timings cap at 50" begin
+        session = AgentREPL.get_current_session!()
+        empty!(session.eval_timings)
+        for i in 1:55
+            push!(session.eval_timings, Float64(i))
+        end
+        # Simulate the cap logic from capture_eval_on_worker
+        while length(session.eval_timings) > 50
+            popfirst!(session.eval_timings)
+        end
+        @test length(session.eval_timings) == 50
+        @test session.eval_timings[1] == 6.0  # first 5 were popped
+    end
+
+    @testset "reset clears timings" begin
+        session = AgentREPL.get_current_session!()
+        AgentREPL.capture_eval_on_worker("1+1")
+        @test !isempty(session.eval_timings)
+        AgentREPL.reset_worker!(session)
+        @test isempty(session.eval_timings)
+    end
+end
+
 # Cleanup: Kill worker at end of tests
 @testset "Cleanup" begin
     session = AgentREPL.get_current_session!()


### PR DESCRIPTION
## Summary

- Add sparkline visualization of eval timings to `info()` tool output
- Every eval stores its elapsed time in a ring buffer (capped at 50)
- `info()` renders: `Eval Timings (5 evals): ▁▃▁▂█  median [45.2ms], max [2.3s]`
- Timings cleared on worker reset

## Changes

- `src/types.jl`: Add `eval_timings` field + `MAX_EVAL_TIMINGS` constant
- `src/worker.jl`: Store elapsed times, clear on reset
- `src/formatting.jl`: `sparkline()` function using Unicode blocks ▁▂▃▄▅▆▇█
- `src/tools.jl`: Render sparkline + median/max in info output
- Tests for sparkline rendering, accumulation, cap, reset

## Test plan

- [x] All 208 unit tests pass
- [x] Code reviewed by 3 specialized agents (reuse, quality, efficiency)
- [x] Simplification pass applied (median fix, constant extraction, test improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)