### PR TITLE
Switch worker backend to Malt.jl; add MCP resources + hardening

### DIFF
--- a/.claude/skills/run-agentrepl/SKILL.md
+++ b/.claude/skills/run-agentrepl/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: run-agentrepl
+description: Build, run, and drive the AgentREPL.jl MCP server. Use when asked to start AgentREPL, launch the Julia REPL MCP server, run its tests, eval Julia code through it, render a plot, or confirm a change works against the running server.
+---
+
+AgentREPL.jl is an MCP server that exposes a persistent Julia REPL (eval, sessions, pkg, revise, plots) over JSON-RPC on STDIO. There is no GUI and no network port, so you drive it by being its MCP client: spawn the server, do the `initialize` handshake, call tools. The driver `.claude/skills/run-agentrepl/driver.mjs` does exactly that — use it for everything below.
+
+All paths are relative to the repo root (`/Users/sam/Research/AgentREPL.jl`).
+
+## Prerequisites
+
+Verified on macOS (darwin), Julia 1.12.6, Node v26. Linux is equivalent — there is nothing platform-specific in the launch path.
+
+- **Julia 1.12+** — the `julia` binary on PATH. Installed here via [juliaup](https://github.com/JuliaLang/juliaup).
+- **Node 18+** — only for `driver.mjs`. Uses Node stdlib only, no `npm install`.
+
+## Setup
+
+`Manifest.toml` is gitignored, so resolve and precompile deps once after clone (~30s cold):
+
+```bash
+julia --project=. -e "using Pkg; Pkg.instantiate(); Pkg.precompile()"
+```
+
+Optional — enable Revise.jl hot-reload. Revise is only a test-extra of this package, not a runtime dep, and the worker inherits your global env on its load path. So hot-reload works only if Revise lives in your default environment:
+
+```bash
+julia -e 'using Pkg; Pkg.activate(); Pkg.add("Revise")'
+```
+
+Without this, `info` reports `Revise.jl: not available` and the server logs one "Worker may have crashed while loading Revise.jl" warning per worker spawn. Eval is unaffected.
+
+## Run (agent path)
+
+Drive the server with `driver.mjs`. It spawns `julia --project=. bin/julia-repl-server`, handles the handshake, and skips the non-JSON chatter the server interleaves on its streams.
+
+Full smoke test — launches, exercises all 8 tools, prints PASS/FAIL, exits non-zero on any failure (~10s warm, after precompile):
+
+```bash
+node .claude/skills/run-agentrepl/driver.mjs
+```
+
+One-shot eval — spawn, eval, print the formatted result, exit:
+
+```bash
+node .claude/skills/run-agentrepl/driver.mjs eval 'using Statistics; mean([1,2,3,4,5])'
+```
+
+Call any tool with a JSON args object:
+
+```bash
+node .claude/skills/run-agentrepl/driver.mjs call info '{}'
+node .claude/skills/run-agentrepl/driver.mjs call session '{"action":"list"}'
+```
+
+Interactive — one Julia expression per stdin line, eval'd on a persistent worker (state carries across lines), Ctrl-D to quit:
+
+```bash
+printf 'x = collect(1:5)\nsum(x)\nusing UnicodePlots\nlineplot(1:10, sin.(1:10), title="sine")\n' \
+  | node .claude/skills/run-agentrepl/driver.mjs repl
+```
+
+| command | what it does |
+|---|---|
+| `driver.mjs` | full smoke test over all 8 tools, PASS/FAIL summary |
+| `driver.mjs eval '<code>'` | one eval, prints the formatted result |
+| `driver.mjs call <tool> '<json>'` | call any tool (`eval`, `reset`, `info`, `pkg`, `activate`, `log_viewer`, `session`, `revise`) |
+| `driver.mjs repl` | interactive eval, one expression per stdin line, state persists |
+
+**Plots are ANSI text, not images.** UnicodePlots renders to a colored ANSI block. The driver prints it to stdout; capture it to a file to inspect:
+
+```bash
+node .claude/skills/run-agentrepl/driver.mjs eval 'using UnicodePlots; lineplot(1:10, (1:10).^2)' > /tmp/agentrepl-plot.txt
+```
+
+Env overrides for the driver: `JULIA_PROJECT_DIR` (point at a different AgentREPL checkout), `JULIA_BIN` (julia executable path).
+
+## Run (human path)
+
+The server is meant to be registered with an MCP client, not run by hand. With Claude Code, install the plugin (`claude /plugin add samtalki/AgentREPL.jl`) or `claude mcp add`; see README.md. To launch it raw and confirm it speaks MCP, pipe a handshake into the bare entry point (it reads JSON-RPC on stdin, writes responses on stdout, and blocks waiting for a client):
+
+```bash
+printf '%s\n%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{},"clientInfo":{"name":"c","version":"1"},"protocolVersion":"2025-06-18"}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | julia --project=. bin/julia-repl-server 2>/dev/null \
+  | grep -o '"name":"[a-z_]*"' | sort -u
+```
+
+Prints the 8 tool names. `JULIA_REPL_PROJECT=/path` activates a project on the worker; `JULIA_REPL_AUDIT_DIR=/path` enables per-session audit logs.
+
+## Test
+
+```bash
+julia --project=. -e "using Pkg; Pkg.test()"           # Aqua + unit suites, 268 tests, ~45s
+AGENTREPL_E2E=true julia --project=. -e "using Pkg; Pkg.test()"   # + real server subprocess + transport test, 303 tests
+```
+
+During tests you'll see `[worker:<session>:stderr] ...` lines — that is the worker's drained stderr (e.g. project-activation chatter, Revise warnings), routed to the test process's stderr on purpose. The suite still ends with `Testing AgentREPL tests passed`.
+
+## Gotchas
+
+- **Framing is newline-delimited JSON, not LSP `Content-Length`.** One JSON object per line. A client written for the LSP framing will hang. The driver and the raw-launch snippet above both assume NDJSON.
+- **The stdout transport is clean JSON; diagnostics go to stderr.** Malt workers keep their stdout/stderr on private pipes (drained to the server's stderr), and the framework's own logs go to stderr too — so the stdout transport carries only JSON-RPC. The driver still skips non-`{` lines defensively, and the bare-launch snippet pipes stderr to `/dev/null`.
+- **First eval is slow; the worker spawns lazily.** No worker exists until the first `eval`/`info`/`pkg` call — that call spawns a Malt worker (and loads UnicodePlots/Revise on it). Cold, budget tens of seconds; the driver's per-request timeout is 120s for this reason. Later evals are milliseconds.
+- **`reset` kills the worker and drops all state.** It returns fast but the *next* eval pays the worker-spawn cost again. Variables, loaded packages, and `using` imports are gone — that is the point (it enables struct/type redefinition).
+- **Revise "not available" is expected on a clean machine.** See Setup. It is graceful degradation, not a failure; eval works regardless.
+- **STDIO only, no port.** You cannot `curl` this server. The single local IPC channel is `session attach` (a chmod-600 Unix socket for an interactive human REPL), which needs `tmux` and is out of scope for headless driving.
+
+## Troubleshooting
+
+- **`timeout (120000ms) waiting for tools/call`**: almost always the cold first-eval worker spawn colliding with a precompile. Run the Setup precompile first, then retry.
+- **Driver prints `server exited (code=1 ...)`**: the Julia process died on launch. Run `julia --project=. -e "using AgentREPL"` directly to see the real error (usually a missing `Manifest.toml` — run the Setup step).
+- **`Package Revise not found` warning floods stderr**: harmless. Silence it for that run by adding Revise to your global env (Setup), or ignore it.

--- a/.claude/skills/run-agentrepl/SKILL.md
+++ b/.claude/skills/run-agentrepl/SKILL.md
@@ -28,7 +28,7 @@ Optional — enable Revise.jl hot-reload. Revise is only a test-extra of this pa
 julia -e 'using Pkg; Pkg.activate(); Pkg.add("Revise")'
 ```
 
-Without this, `info` reports `Revise.jl: not available` and the server logs one "Worker may have crashed while loading Revise.jl" warning per worker spawn. Eval is unaffected.
+Without this, `info` reports `Revise.jl: not available` and the server logs a `Could not load Revise.jl on worker` warning (and records a session note) per worker spawn. Eval is unaffected.
 
 ## Run (agent path)
 
@@ -93,8 +93,8 @@ Prints the 8 tool names. `JULIA_REPL_PROJECT=/path` activates a project on the w
 ## Test
 
 ```bash
-julia --project=. -e "using Pkg; Pkg.test()"           # Aqua + unit suites, 268 tests, ~45s
-AGENTREPL_E2E=true julia --project=. -e "using Pkg; Pkg.test()"   # + real server subprocess + transport test, 303 tests
+julia --project=. -e "using Pkg; Pkg.test()"           # Aqua + unit suites (~45s)
+AGENTREPL_E2E=true julia --project=. -e "using Pkg; Pkg.test()"   # + real server subprocess + transport test
 ```
 
 During tests you'll see `[worker:<session>:stderr] ...` lines — that is the worker's drained stderr (e.g. project-activation chatter, Revise warnings), routed to the test process's stderr on purpose. The suite still ends with `Testing AgentREPL tests passed`.
@@ -103,13 +103,13 @@ During tests you'll see `[worker:<session>:stderr] ...` lines — that is the wo
 
 - **Framing is newline-delimited JSON, not LSP `Content-Length`.** One JSON object per line. A client written for the LSP framing will hang. The driver and the raw-launch snippet above both assume NDJSON.
 - **The stdout transport is clean JSON; diagnostics go to stderr.** Malt workers keep their stdout/stderr on private pipes (drained to the server's stderr), and the framework's own logs go to stderr too — so the stdout transport carries only JSON-RPC. The driver still skips non-`{` lines defensively, and the bare-launch snippet pipes stderr to `/dev/null`.
-- **First eval is slow; the worker spawns lazily.** No worker exists until the first `eval`/`info`/`pkg` call — that call spawns a Malt worker (and loads UnicodePlots/Revise on it). Cold, budget tens of seconds; the driver's per-request timeout is 120s for this reason. Later evals are milliseconds.
-- **`reset` kills the worker and drops all state.** It returns fast but the *next* eval pays the worker-spawn cost again. Variables, loaded packages, and `using` imports are gone — that is the point (it enables struct/type redefinition).
+- **First eval is slow; the worker spawns lazily.** No worker exists until the first `eval`/`pkg` call (or an `info`/`pkg` tool call) — that call spawns a Malt worker and attempts to load Revise on it. UnicodePlots loads only on the first `using UnicodePlots`. Cold, budget tens of seconds; the driver's per-request timeout is 120s for this reason. Later evals are milliseconds.
+- **`reset` kills the worker and drops all state.** It returns fast but the *next* eval pays the worker spawn cost again. Variables, loaded packages, and `using` imports are gone — that is the point (it enables struct/type redefinition).
 - **Revise "not available" is expected on a clean machine.** See Setup. It is graceful degradation, not a failure; eval works regardless.
 - **STDIO only, no port.** You cannot `curl` this server. The single local IPC channel is `session attach` (a chmod-600 Unix socket for an interactive human REPL), which needs `tmux` and is out of scope for headless driving.
 
 ## Troubleshooting
 
-- **`timeout (120000ms) waiting for tools/call`**: almost always the cold first-eval worker spawn colliding with a precompile. Run the Setup precompile first, then retry.
+- **`timeout (120000ms) waiting for tools/call`**: almost always the cold first eval's worker spawn colliding with a precompile. Run the Setup precompile first, then retry.
 - **Driver prints `server exited (code=1 ...)`**: the Julia process died on launch. Run `julia --project=. -e "using AgentREPL"` directly to see the real error (usually a missing `Manifest.toml` — run the Setup step).
-- **`Package Revise not found` warning floods stderr**: harmless. Silence it for that run by adding Revise to your global env (Setup), or ignore it.
+- **`Could not load Revise.jl on worker` warning on stderr**: harmless. Silence it by adding Revise to your global env (Setup), or ignore it.

--- a/.claude/skills/run-agentrepl/driver.mjs
+++ b/.claude/skills/run-agentrepl/driver.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+// driver.mjs - launch and drive the AgentREPL.jl MCP server.
+//
+// AgentREPL is an MCP server that speaks JSON-RPC over STDIO. There is no GUI
+// and no HTTP port. The only way to drive it is to be its MCP client: spawn the
+// server subprocess, do the `initialize` handshake, then call its tools. That is
+// exactly what this script does.
+//
+// Framing note: the server uses NEWLINE-DELIMITED JSON (one JSON object per
+// line), NOT LSP `Content-Length:` framing. The stdout transport stays clean JSON
+// (Malt workers keep their output on private pipes; the server's own logs go to
+// stderr), but we still parse only lines that start with `{` defensively.
+//
+// Usage:
+//   node driver.mjs                     # full smoke test, prints PASS/FAIL, exits non-zero on failure
+//   node driver.mjs eval '<julia code>' # one eval, print the result text, exit
+//   node driver.mjs call <tool> '<json>'# call any tool with a JSON args object
+//   node driver.mjs repl                # interactive: each stdin line is eval'd on the worker
+//
+// Env:
+//   JULIA_PROJECT_DIR  override the AgentREPL project dir (default: repo root, 3 levels up)
+//   JULIA_BIN          julia executable (default: "julia")
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// skill lives at <repo>/.claude/skills/run-agentrepl/, so repo root is 3 up.
+const REPO_DIR = process.env.JULIA_PROJECT_DIR || resolve(__dirname, "..", "..", "..");
+const JULIA = process.env.JULIA_BIN || "julia";
+const SERVER = `${REPO_DIR}/bin/julia-repl-server`;
+
+class MCPClient {
+  constructor() {
+    this.nextId = 1;
+    this.pending = new Map(); // id -> {resolve, reject}
+    this.proc = spawn(JULIA, [`--project=${REPO_DIR}`, SERVER], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.proc.on("exit", (code, sig) => {
+      for (const { reject } of this.pending.values()) {
+        reject(new Error(`server exited (code=${code} sig=${sig})`));
+      }
+      this.pending.clear();
+    });
+    // stdout: JSON-RPC responses interleaved with worker chatter.
+    const out = createInterface({ input: this.proc.stdout });
+    out.on("line", (line) => this._onLine(line));
+    // stderr: @info logs + precompile noise. Mirror it dimmed so launch
+    // progress is visible, but never parse it.
+    const err = createInterface({ input: this.proc.stderr });
+    err.on("line", (line) => process.stderr.write(`\x1b[2m[server] ${line}\x1b[0m\n`));
+  }
+
+  _onLine(line) {
+    const s = line.trim();
+    if (!s.startsWith("{")) return; // worker message / log line — skip
+    let msg;
+    try {
+      msg = JSON.parse(s);
+    } catch {
+      return; // not a complete JSON object on one line — skip
+    }
+    if (msg.id != null && this.pending.has(msg.id)) {
+      const { resolve, reject } = this.pending.get(msg.id);
+      this.pending.delete(msg.id);
+      if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+      else resolve(msg.result);
+    }
+  }
+
+  _send(obj) {
+    this.proc.stdin.write(JSON.stringify(obj) + "\n");
+  }
+
+  notify(method, params = {}) {
+    this._send({ jsonrpc: "2.0", method, params });
+  }
+
+  request(method, params = {}, timeoutMs = 120000) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`timeout (${timeoutMs}ms) waiting for ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (v) => { clearTimeout(timer); resolve(v); },
+        reject: (e) => { clearTimeout(timer); reject(e); },
+      });
+      this._send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  async initialize() {
+    const res = await this.request("initialize", {
+      capabilities: {},
+      clientInfo: { name: "agentrepl-driver", version: "1.0" },
+      protocolVersion: "2025-06-18",
+    }, 60000);
+    this.notify("notifications/initialized");
+    return res;
+  }
+
+  async listTools() {
+    const res = await this.request("tools/list", {}, 30000);
+    return res.tools.map((t) => t.name);
+  }
+
+  // returns the first content block's text
+  async callTool(name, args = {}, timeoutMs = 120000) {
+    const res = await this.request("tools/call", { name, arguments: args }, timeoutMs);
+    return res.content?.[0]?.text ?? JSON.stringify(res);
+  }
+
+  close() {
+    try { this.proc.stdin.end(); } catch {}
+    try { this.proc.kill(); } catch {}
+  }
+}
+
+function ok(cond, label) {
+  console.log(`${cond ? "  \x1b[32mPASS\x1b[0m" : "  \x1b[31mFAIL\x1b[0m"}  ${label}`);
+  return cond;
+}
+
+async function smoke() {
+  const c = new MCPClient();
+  let failures = 0;
+  const check = (cond, label) => { if (!ok(cond, label)) failures++; };
+  try {
+    const init = await c.initialize();
+    check(init?.serverInfo?.name === "julia-repl", `initialize handshake (serverInfo.name=${init?.serverInfo?.name})`);
+
+    const tools = await c.listTools();
+    const expected = ["eval", "reset", "info", "pkg", "activate", "log_viewer", "session", "revise"];
+    check(expected.every((t) => tools.includes(t)), `tools/list has all 8 tools (got: ${tools.join(", ")})`);
+
+    console.log("  ... first eval spawns a worker, ~10-40s");
+    const r1 = await c.callTool("eval", { code: "1 + 1" });
+    check(r1.includes("2"), "eval 1+1 -> 2");
+
+    await c.callTool("eval", { code: "_smoke_x = 42" });
+    const r2 = await c.callTool("eval", { code: "_smoke_x" });
+    check(r2.includes("42"), "variable persists across evals");
+
+    const r3 = await c.callTool("eval", { code: "undefined_zzz" });
+    check(r3.includes("UndefVarError"), "error surfaces (UndefVarError)");
+
+    const r4 = await c.callTool("eval", { code: 'println("hello_driver"); 99' });
+    check(r4.includes("hello_driver") && r4.includes("99"), "stdout + result both captured");
+
+    const info = await c.callTool("info", {});
+    check(info.includes("Julia Version"), "info reports Julia Version");
+
+    const cs = await c.callTool("session", { action: "create", name: "drv-s1" });
+    check(cs.includes("drv-s1"), "session create");
+    const ls = await c.callTool("session", { action: "list" });
+    check(ls.includes("drv-s1") && ls.includes("default"), "session list shows both");
+    await c.callTool("session", { action: "destroy", name: "drv-s1" });
+
+    const plot = await c.callTool("eval", { code: "using UnicodePlots; lineplot(1:10, (1:10).^2)" });
+    check(plot.length > 0 && !plot.includes("ERROR"), "UnicodePlots renders on worker");
+
+    await c.callTool("eval", { code: "_reset_var = 123" });
+    const rst = await c.callTool("reset", {}, 60000);
+    check(rst.toLowerCase().includes("reset"), "reset reports success");
+    const after = await c.callTool("eval", { code: "_reset_var" });
+    check(after.includes("UndefVarError"), "state cleared after reset");
+
+    console.log(failures === 0 ? "\n\x1b[32mALL PASS\x1b[0m" : `\n\x1b[31m${failures} FAILED\x1b[0m`);
+  } catch (e) {
+    console.error("driver error:", e.message);
+    failures++;
+  } finally {
+    c.close();
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+async function oneEval(code) {
+  const c = new MCPClient();
+  try {
+    await c.initialize();
+    const text = await c.callTool("eval", { code });
+    console.log(text);
+  } finally {
+    c.close();
+  }
+  process.exit(0);
+}
+
+async function oneCall(tool, jsonArgs) {
+  const c = new MCPClient();
+  try {
+    await c.initialize();
+    const args = jsonArgs ? JSON.parse(jsonArgs) : {};
+    const text = await c.callTool(tool, args);
+    console.log(text);
+  } finally {
+    c.close();
+  }
+  process.exit(0);
+}
+
+async function repl() {
+  const c = new MCPClient();
+  await c.initialize();
+  console.error("\x1b[2m[driver] initialized. type Julia, one expr per line. Ctrl-D to quit.\x1b[0m");
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    try {
+      console.log(await c.callTool("eval", { code: line }));
+    } catch (e) {
+      console.error("error:", e.message);
+    }
+  }
+  c.close();
+  process.exit(0);
+}
+
+const [, , cmd, ...rest] = process.argv;
+if (cmd === "eval") oneEval(rest.join(" "));
+else if (cmd === "call") oneCall(rest[0], rest[1]);
+else if (cmd === "repl") repl();
+else smoke();

--- a/.claude/skills/run-agentrepl/driver.mjs
+++ b/.claude/skills/run-agentrepl/driver.mjs
@@ -182,27 +182,33 @@ async function smoke() {
 
 async function oneEval(code) {
   const c = new MCPClient();
+  let failed = false;
   try {
     await c.initialize();
-    const text = await c.callTool("eval", { code });
-    console.log(text);
+    console.log(await c.callTool("eval", { code }));
+  } catch (e) {
+    failed = true;
+    console.error("error:", e.message);
   } finally {
     c.close();
   }
-  process.exit(0);
+  process.exit(failed ? 1 : 0);
 }
 
 async function oneCall(tool, jsonArgs) {
   const c = new MCPClient();
+  let failed = false;
   try {
     await c.initialize();
     const args = jsonArgs ? JSON.parse(jsonArgs) : {};
-    const text = await c.callTool(tool, args);
-    console.log(text);
+    console.log(await c.callTool(tool, args));
+  } catch (e) {
+    failed = true;
+    console.error("error:", e.message);
   } finally {
     c.close();
   }
-  process.exit(0);
+  process.exit(failed ? 1 : 0);
 }
 
 async function repl() {

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,3 +54,23 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  e2e:
+    name: E2E MCP protocol (Julia 1.12 - ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.12'
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      # Spawns a real server subprocess and drives it over JSON-RPC (test_mcp_protocol.jl,
+      # including the transport-cleanliness regression test).
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          AGENTREPL_E2E: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Worker backend switched from Distributed.jl to [Malt.jl](https://github.com/JuliaPluto/Malt.jl).** Each session is now a `Malt.Worker`. Malt keeps worker stdout/stderr on private pipes, so worker output can no longer reach the stdout MCP JSON-RPC transport; the pipes are drained to the server's stderr. Removes Distributed's global cluster state and replaces hand-rolled lifecycle/crash handling with Malt's `stop`/`isrunning`/`interrupt`/`TerminatedWorkerException`. `info` and `session` now report the worker OS pid instead of a cluster id.
+
+### Added
+- **MCP resources** exposing live session state for clients to read/@-mention without an extra tool call: `agentrepl://sessions`, `agentrepl://session/variables`, `agentrepl://session/info`, `agentrepl://session/project`, `agentrepl://session/log`.
+- **Tool titles** on all eight tools (human-friendly display names in the client).
+- **Surfaced worker-setup failures**: Revise-load and project-activation failures are recorded in the session and shown in `info` and the next eval result, instead of only being logged to stderr.
+- **Transport-cleanliness regression test** (E2E) asserting worker output never reaches the JSON-RPC stream, plus an E2E job in CI (`AGENTREPL_E2E=true` on Julia 1.12).
+
+### Fixed
+- Server now declares only the capabilities it implements (Tools + Resources), instead of the framework default that advertised resource subscriptions and prompts it does not serve.
+- `info` no longer lists internal temporaries as user variables (the introspection expression is scoped and a baseline of `Main` symbols is excluded).
+
 ## [0.6.0] - 2026-03-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Worker backend switched from Distributed.jl to [Malt.jl](https://github.com/JuliaPluto/Malt.jl).** Each session is now a `Malt.Worker`. Malt keeps worker stdout/stderr on private pipes, so worker output can no longer reach the stdout MCP JSON-RPC transport; the pipes are drained to the server's stderr. Removes Distributed's global cluster state and replaces hand-rolled lifecycle/crash handling with Malt's `stop`/`isrunning`/`interrupt`/`TerminatedWorkerException`. `info` and `session` now report the worker OS pid instead of a cluster id.
+- **Worker backend switched from Distributed.jl to [Malt.jl](https://github.com/JuliaPluto/Malt.jl).** Each session is now a `Malt.Worker`. Malt keeps worker stdout/stderr on private pipes, so worker output can no longer reach the stdout MCP JSON-RPC transport; the pipes are drained to the server's stderr. Removes Distributed's global cluster state and replaces hand-rolled lifecycle/crash handling with Malt's `stop`/`isrunning`/`TerminatedWorkerException`. `info` and `session` now report the worker OS pid instead of a cluster id.
 
 ### Added
 - **MCP resources** exposing live session state for clients to read/@-mention without an extra tool call: `agentrepl://sessions`, `agentrepl://session/variables`, `agentrepl://session/info`, `agentrepl://session/project`, `agentrepl://session/log`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,15 @@ JULIA_REPL_PROJECT=/path/to/project julia --project=. bin/julia-repl-server
 
 ### Multi-Session Worker Subprocess Model
 
-AgentREPL uses a **multi-session worker subprocess architecture** (via Distributed.jl):
+AgentREPL uses a **multi-session worker subprocess architecture** (via [Malt.jl](https://github.com/JuliaPluto/Malt.jl)):
 - The MCP server runs in the main Julia process
-- Each named session has its own worker process for code evaluation
+- Each named session has its own `Malt.Worker` process for code evaluation
 - Sessions are isolated: separate variables, packages, and project environments
 - `reset` kills a session's worker and spawns a fresh one (true hard reset)
 - `activate` switches a session's active project/environment
 - Revise.jl is auto-loaded on workers for hot-reloading support
+
+**Why Malt, not Distributed.jl**: Malt spawns workers with `monitor_stdout=false`/`monitor_stderr=false`, so worker output goes to private pipes (drained to the server's stderr by `_start_output_drain!`) and can never reach the main process's stdout — which is the MCP JSON-RPC transport. Malt also has no global cluster state (each `Worker` is an independent object) and provides graceful `stop` (exit → SIGTERM → SIGKILL), `isrunning`, `interrupt`, and `TerminatedWorkerException`, replacing hand-rolled Distributed lifecycle code. IPC is `Malt.remote_eval_fetch(Main, w, expr)` via the `_remote_eval_fetch` helper.
 
 ### File Structure
 
@@ -43,12 +45,14 @@ src/
   highlighting.jl        # Julia syntax highlighting (uses JuliaSyntaxHighlighting.jl)
   formatting.jl          # Result formatting, stacktrace truncation
   sessions.jl            # Multi-session lifecycle (create, switch, list, destroy)
-  worker.jl              # Distributed worker lifecycle (ensure_worker!, capture_eval_on_worker)
+  worker.jl              # Malt worker lifecycle (ensure_worker!, capture_eval_on_worker, output drain)
   revise.jl              # Revise.jl integration (revise, track, includet on workers)
   packages.jl            # Pkg actions, project activation
-  logging.jl             # Log viewer functionality
+  logging.jl             # Log viewer + persistent audit logging
+  attach.jl              # Interactive shared REPL (Unix socket server on worker + tmux client)
   tools.jl               # MCP tool definitions (8 tools)
-  server.jl              # start_server function
+  resources.jl           # MCP resources (session variables, info, project, log, sessions)
+  server.jl              # start_server function (registers tools + resources, declares capabilities)
 ```
 
 ### Syntax Highlighting
@@ -108,13 +112,17 @@ All tools except `log_viewer` and `session` accept an optional `session` paramet
 
 ### Key Design Decisions
 
-- **Multi-session model**: Each session has its own Distributed.jl worker with isolated state
-- **Revise.jl auto-loading**: Workers attempt `using Revise` on startup (graceful degradation)
+- **Multi-session model**: Each session has its own `Malt.Worker` with isolated state
+- **Revise.jl auto-loading**: Workers attempt `using Revise` on startup (graceful degradation); a load failure is recorded in `session.worker_notes` and surfaced in `info` / the next eval rather than only logged
 - **Lazy worker spawning**: Worker created on first tool use, not at server startup
-- **Expression-based IPC**: Uses `remotecall_fetch(Core.eval, worker_id, Main, expr)` to avoid serialization issues
+- **Expression-based IPC**: Uses `_remote_eval_fetch(w, expr)` (= `Malt.remote_eval_fetch(Main, w, expr)`) to avoid closure serialization issues
+- **Transport isolation**: Workers run with `monitor_stdout/stderr=false`; `_start_output_drain!` drains their pipes to the server's stderr so worker output never corrupts the stdout JSON-RPC stream. `get_worker_info` snapshots a baseline of `Main` symbols at spawn so Malt's own worker-loop globals don't show up as user variables
+- **Capabilities**: `start_server` declares only Tools + Resources (no prompts, no resource subscriptions) instead of the framework default, which over-advertises
 - **STDIO transport only**: No network ports for security
 - **Environment persistence**: Activated environment survives reset
 - **Output-then-result formatting**: Shows stdout first, then result/error, then timing — optimized for collapsed view UX
+
+**Framework limitations (would need a ModelContextProtocol.jl PR):** the `MCPTool` struct has no `annotations` field and `handle_list_tools` does not serialize one, so tool hints (`readOnlyHint`/`destructiveHint`) are not available — only `title` is. There is no tool `output_schema`/`structuredContent` support, so tools return text and richer structured state is exposed via **resources** instead.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ AgentREPL uses a **multi-session worker subprocess architecture** (via [Malt.jl]
 - `activate` switches a session's active project/environment
 - Revise.jl is auto-loaded on workers for hot-reloading support
 
-**Why Malt, not Distributed.jl**: Malt spawns workers with `monitor_stdout=false`/`monitor_stderr=false`, so worker output goes to private pipes (drained to the server's stderr by `_start_output_drain!`) and can never reach the main process's stdout — which is the MCP JSON-RPC transport. Malt also has no global cluster state (each `Worker` is an independent object) and provides graceful `stop` (exit → SIGTERM → SIGKILL), `isrunning`, `interrupt`, and `TerminatedWorkerException`, replacing hand-rolled Distributed lifecycle code. IPC is `Malt.remote_eval_fetch(Main, w, expr)` via the `_remote_eval_fetch` helper.
+**Why Malt, not Distributed.jl**: Malt spawns workers with `monitor_stdout=false`/`monitor_stderr=false`, so worker output goes to private pipes (drained to the server's stderr by `_start_output_drain!`) and can never reach the main process's stdout — which is the MCP JSON-RPC transport. Malt also has no global cluster state (each `Worker` is an independent object) and provides graceful `stop` (exit → SIGTERM → SIGKILL), `isrunning`, and `TerminatedWorkerException`, replacing hand-rolled Distributed lifecycle code. IPC is `Malt.remote_eval_fetch(Main, w, expr)` via the `_remote_eval_fetch` helper.
 
 ### File Structure
 
@@ -126,16 +126,17 @@ All tools except `log_viewer` and `session` accept an optional `session` paramet
 
 ## Testing
 
-Tests are in `test/runtests.jl`, `test/test_eval.jl`, `test/test_sessions.jl`, `test/test_revise.jl`, and `test/test_highlighting.jl` covering:
+`test/runtests.jl` runs an Aqua.jl quality pass then the unit suites: `test_highlighting.jl`, `test_eval.jl`, `test_sessions.jl`, `test_competitive_features.jl`, `test_revise.jl`, and `test_resources.jl`. `test/test_mcp_protocol.jl` is gated behind `AGENTREPL_E2E=true` (it spawns a real server subprocess). Coverage:
 - Code evaluation (arithmetic, variables, functions, multi-line)
 - Output capture and error handling
 - Result formatting and truncation
-- Worker subprocess lifecycle (spawn, reset, persistence)
-- Multi-session management (create, switch, isolate, destroy)
-- Session-targeted evaluation
-- Pkg actions (test, develop, free)
-- Revise.jl integration (status, availability)
+- Worker subprocess lifecycle (spawn, reset, timeout kill, crash recovery, persistence)
+- `worker_notes` surfacing (Revise/activation failures shown in info/eval then cleared)
+- Multi-session management (create, switch, isolate, destroy), session-targeted eval
+- Pkg actions (test, develop, free); Revise.jl integration (status, availability)
+- MCP resources (the five providers, error path, audit-log branches)
 - Syntax highlighting (ANSI, markdown, plain formats)
+- E2E MCP protocol over the server subprocess, incl. transport-stream cleanliness
 
 ## Entry Point
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,11 +139,11 @@ Understanding the architecture will help you contribute effectively:
 
 ### Worker Subprocess Model
 
-AgentREPL uses Distributed.jl to spawn a worker subprocess:
+AgentREPL uses [Malt.jl](https://github.com/JuliaPluto/Malt.jl) to spawn a worker subprocess:
 
 ```
 Main Process (MCP Server)
-    ↕ remotecall_fetch via Distributed.jl
+    ↕ Malt.remote_eval_fetch (via _remote_eval_fetch)
 Worker Process (Code Evaluation)
 ```
 
@@ -160,7 +160,7 @@ Key benefits:
 | `src/types.jl` | State structs (SessionState, SessionRegistry, etc.) |
 | `src/tools.jl` | MCP tool definitions (8 tools) |
 | `src/sessions.jl` | Multi-session lifecycle management |
-| `src/worker.jl` | Distributed worker lifecycle |
+| `src/worker.jl` | Malt worker lifecycle |
 | `src/revise.jl` | Revise.jl integration |
 | `src/highlighting.jl` | Syntax highlighting |
 | `src/formatting.jl` | Result formatting, stacktrace truncation |

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,8 @@ authors = ["Samuel Talkington <talkington@pm.me>"]
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JuliaSyntaxHighlighting = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+Malt = "36869731-bdee-424d-aa32-cab38c994e3b"
 ModelContextProtocol = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
@@ -14,9 +14,9 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 [compat]
 Aqua = "0.8"
 Dates = "1"
-Distributed = "1"
 JSON3 = "1"
 JuliaSyntaxHighlighting = "1"
+Malt = "1.4"
 ModelContextProtocol = "0.4"
 Pkg = "1"
 Revise = "3"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AgentREPL is the simplest way to give Claude Code a persistent Julia session. Th
 
 2. **Workflow-native Revise.jl.** Every worker auto-loads Revise.jl. The plugin's PostToolUse hook automatically calls `revise` after you edit `.jl` files. You never manually reload code.
 
-3. **True process isolation.** Each session is a separate Distributed.jl worker. You can redefine structs, kill crashed sessions, and run parallel workloads without cross-contamination. `reset` does what it says -- complete state erasure including type definitions.
+3. **True process isolation.** Each session is a separate Malt.jl worker process. You can redefine structs, kill crashed sessions, and run parallel workloads without cross-contamination. `reset` does what it says -- complete state erasure including type definitions.
 
 AgentREPL is not a Julia IDE replacement. It has 8 tools, not 35. It does not have debugging, semantic search, or a dashboard. If you need those, see the [comparison section](#choosing-a-julia-mcp-server) below. AgentREPL's approach is that `eval` plus Julia's existing introspection capabilities (which you can call directly via `eval`) covers most agent workflows with minimal complexity.
 
@@ -72,7 +72,7 @@ The first call may take a few seconds for JIT compilation; subsequent calls are 
 
 ## Architecture
 
-AgentREPL uses a **multi-session worker subprocess model** via Distributed.jl:
+AgentREPL uses a **multi-session worker subprocess model** via [Malt.jl](https://github.com/JuliaPluto/Malt.jl):
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -80,14 +80,18 @@ AgentREPL uses a **multi-session worker subprocess model** via Distributed.jl:
 │   ↕ STDIO (MCP)                                        │
 │ ┌─────────────────────────────────────────────────────┐ │
 │ │ AgentREPL MCP Server (Main Process)                 │ │
-│ │   ↕ Distributed.jl                                  │ │
+│ │   ↕ Malt.jl                                         │ │
 │ │ ┌──────────────────┐  ┌──────────────────┐          │ │
 │ │ │ Session "default" │  │ Session "testing" │  ...    │ │
-│ │ │ (Worker 2)        │  │ (Worker 3)        │         │ │
+│ │ │ (worker process)  │  │ (worker process)  │         │ │
 │ │ └──────────────────┘  └──────────────────┘          │ │
 │ └─────────────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────┘
 ```
+
+Malt (the worker library behind Pluto.jl) keeps each worker's stdout/stderr on a
+private pipe instead of the host's streams, so worker output can never corrupt the
+MCP JSON-RPC transport that shares the main process's stdout.
 
 **Why a worker subprocess?**
 - `reset` can kill and respawn the worker for a **true hard reset**
@@ -335,6 +339,18 @@ Use `revise` after editing `.jl` files. Use `reset` only for struct layout chang
 
 All tools except `log_viewer` and `session` accept an optional `session` parameter to target a specific session.
 
+## Resources
+
+Alongside the tools, AgentREPL exposes the current session's state as MCP resources, which a client can pull into context (Claude Code surfaces them as @-mentions) without spending an `eval` or `info` call. Each returns JSON:
+
+| URI | Contents |
+|-----|----------|
+| `agentrepl://sessions` | All sessions with worker pid, project, Revise status, age |
+| `agentrepl://session/variables` | User-defined variables in the current session (name, type, size) |
+| `agentrepl://session/info` | Julia version, project, module count, Revise status, worker pid, setup notes |
+| `agentrepl://session/project` | The active `Project.toml` and whether a `Manifest.toml` is present |
+| `agentrepl://session/log` | Recent audit-log entries (when `JULIA_REPL_AUDIT_DIR` is set) |
+
 ## Configuration
 
 ### Environment/Project Management
@@ -366,8 +382,8 @@ The activated environment persists across `reset` calls.
 | Transport | STDIO | HTTP (+ZMQ) | HTTP |
 | Network port | None | 2828 | 3000 |
 | Auto-start from Claude Code | Yes | No | No |
-| Dependencies | 5 (3 stdlib) | 30+ | Few |
-| Session isolation | Process-level (Distributed.jl) | Via Gate | Shared REPL |
+| Dependencies | 6 (3 stdlib) | 30+ | Few |
+| Session isolation | Process-level (Malt.jl) | Via Gate | Shared REPL |
 | Revise.jl integration | Auto-load + auto-revise hook | Manual | No |
 | True hard reset (type redef) | Yes | N/A | No |
 | Debugging (breakpoints, stepping) | No | Yes (VS Code) | No |
@@ -501,11 +517,13 @@ src/
   highlighting.jl        # Julia syntax highlighting (JuliaSyntaxHighlighting.jl)
   formatting.jl          # Result formatting, stacktrace truncation
   sessions.jl            # Multi-session lifecycle (create, switch, list, destroy)
-  worker.jl              # Distributed worker lifecycle
+  worker.jl              # Malt worker lifecycle
   revise.jl              # Revise.jl integration (revise, track, includet, status)
   packages.jl            # Pkg actions, project activation
-  logging.jl             # Log viewer functionality
+  logging.jl             # Log viewer + persistent audit logging
+  attach.jl              # Interactive shared REPL (Unix socket + tmux client)
   tools.jl               # MCP tool definitions (8 tools)
+  resources.jl           # MCP resources (session variables, info, project, log)
   server.jl              # start_server function
 ```
 
@@ -513,7 +531,7 @@ src/
 
 | Component | File | Description |
 |-----------|------|-------------|
-| `SessionState` | types.jl | Per-session state: worker ID, project path, Revise status |
+| `SessionState` | types.jl | Per-session state: worker handle, project path, Revise status |
 | `SessionRegistry` | types.jl | Registry of all sessions with current-session tracking |
 | `LogViewerState` | types.jl | Optional log viewer terminal state |
 | `HighlightConfig` | types.jl | Syntax highlighting configuration |

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -64,7 +64,7 @@ All tools except `log_viewer` and `session` accept an optional `session` paramet
 
 AgentREPL uses a **multi-session worker subprocess model**:
 - The MCP server runs in the main Julia process
-- Each session has its own worker process (via Distributed.jl)
+- Each session has its own worker process (via Malt.jl)
 - Workers are isolated: separate state, packages, project environments
 - Revise.jl is auto-loaded on each worker for hot-reloading
 - `reset` kills a session's worker and spawns a fresh one

--- a/claude-plugin/skills/julia-session/SKILL.md
+++ b/claude-plugin/skills/julia-session/SKILL.md
@@ -39,7 +39,7 @@ Call `session` with the appropriate action and name parameters.
 ## Session Lifecycle
 
 1. Sessions start with no worker — workers spawn lazily on first `eval`
-2. Each session gets its own Distributed.jl worker process
+2. Each session gets its own Malt.jl worker process
 3. Variables, packages, and project environment are fully isolated between sessions
 4. Revise.jl is auto-loaded on each worker if available
 5. The "default" session is auto-created if you use `eval` without creating a session first

--- a/src/AgentREPL.jl
+++ b/src/AgentREPL.jl
@@ -9,7 +9,7 @@ the REPL stays alive and you only pay the startup cost once.
 
 # Architecture
 
-AgentREPL uses a multi-session worker subprocess model via Distributed.jl:
+AgentREPL uses a multi-session worker subprocess model via Malt.jl:
 - The MCP server runs in the main process (STDIO transport)
 - Code evaluation happens in spawned worker processes (one per session)
 - Multiple named sessions can run concurrently with isolated state
@@ -49,7 +49,7 @@ claude mcp add julia-repl -- julia --project=/path/to/AgentREPL.jl /path/to/Agen
 module AgentREPL
 
 using ModelContextProtocol
-using Distributed
+import Malt
 using Pkg
 using Dates
 using JuliaSyntaxHighlighting
@@ -67,6 +67,7 @@ include("packages.jl")
 include("logging.jl")
 include("attach.jl")
 include("tools.jl")
+include("resources.jl")
 include("server.jl")
 
 function __init__()

--- a/src/attach.jl
+++ b/src/attach.jl
@@ -29,8 +29,8 @@ Note: The interactive REPL and MCP eval share the same worker process. Concurren
 evaluation from both paths may produce interleaved stdout/stderr output.
 """
 function _start_repl_socket_server!(session::SessionState)
+    worker_live(session) || error("Session '$(session.name)' has no running worker. Call eval first to spawn one.")
     worker = session.worker
-    (worker === nothing || !Malt.isrunning(worker)) && error("Session '$(session.name)' has no running worker. Call eval first to spawn one.")
 
     sock_path = _socket_path(session.name)
 

--- a/src/attach.jl
+++ b/src/attach.jl
@@ -23,14 +23,14 @@ Protocol (line-based, base64-encoded):
 
 Socket cleanup relies on worker kill — no explicit server stop mechanism exists.
 listen() and chmod() run synchronously before the @async accept loop, so start
-failures are detected immediately by remotecall_fetch.
+failures are detected immediately by remote_eval_fetch.
 
 Note: The interactive REPL and MCP eval share the same worker process. Concurrent
 evaluation from both paths may produce interleaved stdout/stderr output.
 """
 function _start_repl_socket_server!(session::SessionState)
-    worker_id = session.worker_id
-    worker_id === nothing && error("Session '$(session.name)' has no worker. Call eval first to spawn one.")
+    worker = session.worker
+    (worker === nothing || !Malt.isrunning(worker)) && error("Session '$(session.name)' has no running worker. Call eval first to spawn one.")
 
     sock_path = _socket_path(session.name)
 
@@ -107,7 +107,7 @@ function _start_repl_socket_server!(session::SessionState)
     end
 
     try
-        result = remotecall_fetch(Core.eval, worker_id, Main, server_expr)
+        result = _remote_eval_fetch(worker, server_expr)
         session.socket_path = sock_path
         return sock_path
     catch e

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -12,7 +12,7 @@ Supports:
 """
 function activate_project_on_worker!(path::String; session_name::Union{String,Nothing}=nothing)
     session = resolve_session(session_name)
-    worker_id = ensure_worker!(session)
+    worker = ensure_worker!(session)
 
     # Handle shared environment syntax (@v1.12, @myenv, etc.)
     # The @ prefix syntax only works in Pkg REPL mode, not programmatically
@@ -41,7 +41,7 @@ function activate_project_on_worker!(path::String; session_name::Union{String,No
     end
 
     try
-        result = remotecall_fetch(Core.eval, worker_id, Main, activate_expr)
+        result = _remote_eval_fetch(worker, activate_expr)
         if result.success
             session.project_path = result.project
             session.workspace_path = result.project
@@ -60,7 +60,7 @@ Run a Pkg action on the worker process.
 """
 function run_pkg_action_on_worker(action::String, pkg_list::Vector{String}; session_name::Union{String,Nothing}=nothing)
     session = resolve_session(session_name)
-    worker_id = ensure_worker!(session)
+    worker = ensure_worker!(session)
 
     pkg_expr = quote
         let act = $action, pkgs = $pkg_list
@@ -110,7 +110,7 @@ function run_pkg_action_on_worker(action::String, pkg_list::Vector{String}; sess
     end
 
     try
-        return remotecall_fetch(Core.eval, worker_id, Main, pkg_expr)
+        return _remote_eval_fetch(worker, pkg_expr)
     catch e
         _handle_worker_crash!(session, e)
         return (error = "Worker communication failed during Pkg.$action: $(sprint(showerror, e))",

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -49,7 +49,7 @@ function activate_project_on_worker!(path::String; session_name::Union{String,No
         return result
     catch e
         _handle_worker_crash!(session, e)
-        return (success = false, error = "Worker communication failed during Pkg.activate: $(sprint(showerror, e))")
+        return (success = false, error = "Pkg.activate failed — $(_crash_message(e))")
     end
 end
 
@@ -113,7 +113,7 @@ function run_pkg_action_on_worker(action::String, pkg_list::Vector{String}; sess
         return _remote_eval_fetch(worker, pkg_expr)
     catch e
         _handle_worker_crash!(session, e)
-        return (error = "Worker communication failed during Pkg.$action: $(sprint(showerror, e))",
+        return (error = "Pkg.$action failed — $(_crash_message(e))",
                 stdout = "", stderr = "")
     end
 end

--- a/src/repl_client.jl
+++ b/src/repl_client.jl
@@ -3,7 +3,7 @@
 #
 # Usage: julia repl_client.jl <socket_path> [session_name]
 #
-# This script connects to a Unix domain socket server running inside a Distributed.jl worker,
+# This script connects to a Unix domain socket server running inside a Malt worker,
 # providing a human-friendly REPL that shares state with the MCP agent.
 
 using Sockets: connect

--- a/src/resources.jl
+++ b/src/resources.jl
@@ -3,22 +3,33 @@
 # Resources let Claude Code pull session state into context (e.g. @-mention) without
 # spending an eval/info tool call. Each data_provider is zero-arg and reads live
 # state; the framework JSON-encodes whatever it returns, so providers return
-# NamedTuples/Dicts (mime_type "application/json"). Providers never throw — failures
-# come back as an `error` field so a resource read degrades instead of erroring.
+# NamedTuples (mime_type "application/json").
+#
+# Contract:
+# - A resource READ has no side effects: providers never spawn a worker. When no
+#   live worker exists they report what is known without forcing one, so an
+#   @-mention cannot cold-start a Julia process.
+# - Providers never throw. `_resource_safe` wraps each: success is tagged
+#   `ok = true`, failure is `(ok = false, error = ...)`. The `ok` flag is a
+#   dedicated discriminant that cannot collide with a payload field.
+# - Any worker access goes through `get_worker_info` (which self-heals on crash),
+#   guarded by `worker_live`, never a raw `_remote_eval_fetch`.
 
 """
-    _resource_safe(f) -> Any
+    _resource_safe(f) -> NamedTuple
 
-Run a resource data_provider body, returning its value or an `(error = ...)`
-NamedTuple if it throws. Keeps `resources/read` from hard-failing.
+Run a resource data_provider body. On success returns its NamedTuple tagged with
+`ok = true`; on failure returns `(ok = false, error = ...)`. Keeps `resources/read`
+from hard-failing while giving the client an unambiguous success/failure flag.
+`InterruptException`/`OutOfMemoryError` propagate (never swallowed into `error`).
 """
 function _resource_safe(f)
     try
-        return f()
+        return merge((ok = true,), f())
     catch e
         e isa InterruptException && rethrow()
         e isa OutOfMemoryError && rethrow()
-        return (error = sprint(showerror, e),)
+        return (ok = false, error = sprint(showerror, e))
     end
 end
 
@@ -27,9 +38,9 @@ end
 _resource_sessions() = _resource_safe() do
     (sessions = [(
         name = s.name,
-        worker_pid = s.worker_id,
+        worker_pid = s.worker_pid,
         project = s.project,
-        revise = s.revise,
+        revise_loaded = s.revise,
         is_current = s.is_current,
         age_seconds = round(s.age_seconds; digits=1),
     ) for s in list_sessions()],
@@ -38,19 +49,29 @@ end
 
 _resource_variables() = _resource_safe() do
     session = get_current_session!()
-    info = get_worker_info(session)
-    (session = session.name,
-     variables = [(name = string(v.name), type = v.type, size = v.size) for v in info.variables])
+    live = worker_live(session)
+    vars = live ?
+        [(name = string(v.name), type = v.type, size = v.size) for v in get_worker_info(session).variables] :
+        NamedTuple{(:name, :type, :size), Tuple{String,String,String}}[]
+    (session = session.name, worker_spawned = live, variables = vars)
 end
 
 _resource_info() = _resource_safe() do
     session = get_current_session!()
-    info = get_worker_info(session)
+    live = worker_live(session)
+    modules = 0
+    project = something(session.project_path, "(default)")
+    if live
+        wi = get_worker_info(session)  # worker already live → no spawn
+        modules = wi.modules
+        project = wi.project
+    end
     (session = session.name,
      is_current = session.name == SESSIONS.current,
-     julia_version = info.version,
-     project = info.project,
-     loaded_modules = info.modules,
+     worker_spawned = live,
+     julia_version = string(VERSION),  # worker shares this Julia binary
+     project = project,
+     loaded_modules = modules,
      revise_loaded = session.revise_loaded,
      worker_pid = worker_pid(session),
      eval_count = length(session.eval_timings),
@@ -60,9 +81,8 @@ end
 _resource_project() = _resource_safe() do
     session = get_current_session!()
     dir = session.project_path
-    if dir === nothing
-        info = get_worker_info(session)
-        dir = info.project
+    if dir === nothing && worker_live(session)
+        dir = get_worker_info(session).project
     end
     project_toml = ""
     manifest_present = false
@@ -105,11 +125,11 @@ function agentrepl_resources()
             mime_type = "application/json", data_provider = _resource_sessions),
         MCPResource(; uri = "agentrepl://session/variables",
             name = "Current session variables",
-            description = "User-defined variables in the current session (name, type, size). Spawns the worker if needed.",
+            description = "User-defined variables in the current session (name, type, size). Empty until a worker is spawned; reading does not spawn one.",
             mime_type = "application/json", data_provider = _resource_variables),
         MCPResource(; uri = "agentrepl://session/info",
             name = "Current session info",
-            description = "Julia version, active project, loaded module count, Revise status, worker pid, and setup notes for the current session.",
+            description = "Julia version, active project, loaded module count, Revise status, worker pid, and setup notes for the current session. Reading does not spawn a worker.",
             mime_type = "application/json", data_provider = _resource_info),
         MCPResource(; uri = "agentrepl://session/project",
             name = "Current session project",

--- a/src/resources.jl
+++ b/src/resources.jl
@@ -1,0 +1,123 @@
+# resources.jl - MCP resources exposing session state to the client.
+#
+# Resources let Claude Code pull session state into context (e.g. @-mention) without
+# spending an eval/info tool call. Each data_provider is zero-arg and reads live
+# state; the framework JSON-encodes whatever it returns, so providers return
+# NamedTuples/Dicts (mime_type "application/json"). Providers never throw — failures
+# come back as an `error` field so a resource read degrades instead of erroring.
+
+"""
+    _resource_safe(f) -> Any
+
+Run a resource data_provider body, returning its value or an `(error = ...)`
+NamedTuple if it throws. Keeps `resources/read` from hard-failing.
+"""
+function _resource_safe(f)
+    try
+        return f()
+    catch e
+        e isa InterruptException && rethrow()
+        e isa OutOfMemoryError && rethrow()
+        return (error = sprint(showerror, e),)
+    end
+end
+
+# --- data providers ---
+
+_resource_sessions() = _resource_safe() do
+    (sessions = [(
+        name = s.name,
+        worker_pid = s.worker_id,
+        project = s.project,
+        revise = s.revise,
+        is_current = s.is_current,
+        age_seconds = round(s.age_seconds; digits=1),
+    ) for s in list_sessions()],
+     current = SESSIONS.current)
+end
+
+_resource_variables() = _resource_safe() do
+    session = get_current_session!()
+    info = get_worker_info(session)
+    (session = session.name,
+     variables = [(name = string(v.name), type = v.type, size = v.size) for v in info.variables])
+end
+
+_resource_info() = _resource_safe() do
+    session = get_current_session!()
+    info = get_worker_info(session)
+    (session = session.name,
+     is_current = session.name == SESSIONS.current,
+     julia_version = info.version,
+     project = info.project,
+     loaded_modules = info.modules,
+     revise_loaded = session.revise_loaded,
+     worker_pid = worker_pid(session),
+     eval_count = length(session.eval_timings),
+     notes = copy(session.worker_notes))
+end
+
+_resource_project() = _resource_safe() do
+    session = get_current_session!()
+    dir = session.project_path
+    if dir === nothing
+        info = get_worker_info(session)
+        dir = info.project
+    end
+    project_toml = ""
+    manifest_present = false
+    if dir !== nothing && isdir(dir)
+        ptoml = joinpath(dir, "Project.toml")
+        isfile(ptoml) && (project_toml = read(ptoml, String))
+        manifest_present = isfile(joinpath(dir, "Manifest.toml"))
+    end
+    (session = session.name, project_dir = dir,
+     project_toml = project_toml, manifest_present = manifest_present)
+end
+
+_resource_log() = _resource_safe() do
+    session = get_current_session!()
+    if _AUDIT_DIR[] === nothing
+        return (session = session.name, audit_enabled = false,
+                note = "Audit logging is disabled. Set JULIA_REPL_AUDIT_DIR to enable a persistent per-session log.")
+    end
+    date_str = Dates.format(Dates.today(), "yyyy-mm-dd")
+    path = joinpath(_AUDIT_DIR[], "$(session.name)_$(date_str).log")
+    if !isfile(path)
+        return (session = session.name, audit_enabled = true, path = path, tail = String[],
+                note = "No audit entries yet today.")
+    end
+    lines = readlines(path)
+    tail = length(lines) > 200 ? lines[end-199:end] : lines
+    (session = session.name, audit_enabled = true, path = path, tail = tail)
+end
+
+"""
+    agentrepl_resources() -> Vector{MCPResource}
+
+Build the MCP resources exposing live session state. Registered in `start_server`.
+"""
+function agentrepl_resources()
+    MCPResource[
+        MCPResource(; uri = "agentrepl://sessions",
+            name = "Sessions",
+            description = "All AgentREPL sessions with worker pid, project, Revise status, and age.",
+            mime_type = "application/json", data_provider = _resource_sessions),
+        MCPResource(; uri = "agentrepl://session/variables",
+            name = "Current session variables",
+            description = "User-defined variables in the current session (name, type, size). Spawns the worker if needed.",
+            mime_type = "application/json", data_provider = _resource_variables),
+        MCPResource(; uri = "agentrepl://session/info",
+            name = "Current session info",
+            description = "Julia version, active project, loaded module count, Revise status, worker pid, and setup notes for the current session.",
+            mime_type = "application/json", data_provider = _resource_info),
+        MCPResource(; uri = "agentrepl://session/project",
+            name = "Current session project",
+            description = "The active project directory, its Project.toml contents, and whether a Manifest.toml is present.",
+            mime_type = "application/json", data_provider = _resource_project),
+        MCPResource(; uri = "agentrepl://session/log",
+            name = "Current session log",
+            description = "Recent audit-log entries for the current session (when JULIA_REPL_AUDIT_DIR is set).",
+            mime_type = "application/json", data_provider = _resource_log),
+    ]
+end

--- a/src/revise.jl
+++ b/src/revise.jl
@@ -6,7 +6,7 @@
 Check if Revise.jl is loaded on the session's worker.
 """
 function is_revise_available(session::SessionState)
-    return session.revise_loaded && session.worker !== nothing && Malt.isrunning(session.worker)
+    return session.revise_loaded && worker_live(session)
 end
 
 _revise_unavailable_msg(session::SessionState) =
@@ -35,7 +35,7 @@ function revise_on_worker!(session::SessionState)
         return result
     catch e
         _handle_worker_crash!(session, e)
-        return (success = false, message = "Error calling Revise.revise(): $(sprint(showerror, e))")
+        return (success = false, message = "Revise.revise() failed — $(_crash_message(e))")
     end
 end
 
@@ -74,7 +74,7 @@ function _revise_file_action(session::SessionState, filepath::String, action::Sy
         return result
     catch e
         _handle_worker_crash!(session, e)
-        return (success = false, message = "Error $verb file: $(sprint(showerror, e))")
+        return (success = false, message = "$verb file failed — $(_crash_message(e))")
     end
 end
 
@@ -129,6 +129,6 @@ function get_revise_status(session::SessionState)
     catch e
         _handle_worker_crash!(session, e)
         return (available = false, tracked_files = String[], watched_packages = String[],
-                note = "Failed to query Revise status: $(sprint(showerror, e))")
+                note = "Failed to query Revise status — $(_crash_message(e))")
     end
 end

--- a/src/revise.jl
+++ b/src/revise.jl
@@ -6,7 +6,7 @@
 Check if Revise.jl is loaded on the session's worker.
 """
 function is_revise_available(session::SessionState)
-    return session.revise_loaded && session.worker_id !== nothing && session.worker_id in workers()
+    return session.revise_loaded && session.worker !== nothing && Malt.isrunning(session.worker)
 end
 
 _revise_unavailable_msg(session::SessionState) =
@@ -24,7 +24,7 @@ function revise_on_worker!(session::SessionState)
     end
 
     try
-        result = remotecall_fetch(Core.eval, session.worker_id, Main, quote
+        result = _remote_eval_fetch(session.worker, quote
             try
                 Revise.revise()
                 (success = true, message = "Revise completed — all tracked file changes have been loaded.")
@@ -61,7 +61,7 @@ function _revise_file_action(session::SessionState, filepath::String, action::Sy
         "Included and tracking '$(filepath)'. Changes will be auto-loaded on revise()."
 
     try
-        result = remotecall_fetch(Core.eval, session.worker_id, Main, quote
+        result = _remote_eval_fetch(session.worker, quote
             let fp = $filepath
                 try
                     $action_expr
@@ -108,7 +108,7 @@ function get_revise_status(session::SessionState)
     end
 
     try
-        result = remotecall_fetch(Core.eval, session.worker_id, Main, quote
+        result = _remote_eval_fetch(session.worker, quote
             try
                 watched = String[]
                 # NOTE: Revise.watched_files and Revise.pkgdatas are internal APIs,

--- a/src/server.jl
+++ b/src/server.jl
@@ -11,12 +11,17 @@ Start the AgentREPL MCP server using STDIO transport.
 # Tools Provided
 - `eval`: Evaluate Julia code with persistent state
 - `reset`: Hard reset (kills worker, spawns fresh one, enables type redefinition)
-- `info`: Get session information (version, project, variables, Revise status, worker ID, session name)
+- `info`: Get session information (version, project, variables, Revise status, worker pid, session name)
 - `pkg`: Manage packages (add, rm, status, update, instantiate, resolve, test, develop, free)
 - `activate`: Switch active project/environment
 - `log_viewer`: Control the log viewer for visual output
 - `session`: Manage multiple named sessions (create, switch, list, destroy)
 - `revise`: Hot-reload code changes via Revise.jl (revise, track, includet, status)
+
+# Resources Provided
+Read-only views of session state (no side effects, never spawn a worker):
+`agentrepl://sessions`, `agentrepl://session/variables`, `agentrepl://session/info`,
+`agentrepl://session/project`, `agentrepl://session/log`.
 
 # Example
 ```julia

--- a/src/server.jl
+++ b/src/server.jl
@@ -70,12 +70,25 @@ function start_server(; project_dir::Union{String,Nothing}=nothing)
     session_tool = create_session_tool()
     revise_tool = create_revise_tool()
 
+    # Resources expose live session state (variables, info, project, log) to the client.
+    resources = agentrepl_resources()
+
+    # Declare only the capabilities we actually implement. The framework default
+    # advertises resource subscriptions and prompts we don't serve; override it so
+    # clients see an accurate picture.
+    capabilities = ModelContextProtocol.Capability[
+        ModelContextProtocol.ToolCapability(list_changed=false),
+        ModelContextProtocol.ResourceCapability(list_changed=false, subscribe=false),
+    ]
+
     # Create and start the server
     server = mcp_server(
         name = "julia-repl",
         version = "0.6.0",
         description = "Persistent Julia REPL for AI agents - multi-session with Revise.jl hot-reloading",
-        tools = [eval_tool, reset_tool, info_tool, pkg_tool, activate_tool, log_viewer_tool, session_tool, revise_tool]
+        tools = [eval_tool, reset_tool, info_tool, pkg_tool, activate_tool, log_viewer_tool, session_tool, revise_tool],
+        resources = resources,
+        capabilities = capabilities
     )
 
     @info "AgentREPL server starting..." julia_version=VERSION

--- a/src/sessions.jl
+++ b/src/sessions.jl
@@ -94,7 +94,7 @@ function list_sessions()
     for (name, session) in SESSIONS.sessions
         push!(results, (
             name = name,
-            worker_id = session.worker_id,
+            worker_id = worker_pid(session),
             project = session.project_path,
             revise = session.revise_loaded,
             is_current = (name == SESSIONS.current),
@@ -137,13 +137,17 @@ Kill all worker processes across all sessions. Called via atexit() hook
 to prevent orphan Julia processes when the MCP server exits.
 """
 function _cleanup_all_workers!()
-    # Batch rmprocs so total wait is bounded at 5s regardless of session count
-    ids = Int[s.worker_id for (_, s) in SESSIONS.sessions
-              if s.worker_id !== nothing && s.worker_id in workers()]
-    try
-        isempty(ids) || rmprocs(ids; waitfor=5.0)
-    catch e
-        try; println(stderr, "AgentREPL: failed to clean up workers $ids: ", sprint(showerror, e)); catch; end
+    # Stop all workers concurrently so total wait stays bounded regardless of
+    # session count (Malt.stop escalates exit → SIGTERM → SIGKILL per worker).
+    @sync for (_, s) in SESSIONS.sessions
+        if s.worker !== nothing && Malt.isrunning(s.worker)
+            w = s.worker
+            @async try
+                Malt.stop(w; exit_timeout=2.0, term_timeout=2.0)
+            catch e
+                try; println(stderr, "AgentREPL: failed to stop a worker: ", sprint(showerror, e)); catch; end
+            end
+        end
     end
     for (_, s) in SESSIONS.sessions
         _clear_worker_state!(s)

--- a/src/sessions.jl
+++ b/src/sessions.jl
@@ -89,12 +89,12 @@ end
 List all sessions with summary information.
 """
 function list_sessions()
-    results = NamedTuple{(:name, :worker_id, :project, :revise, :is_current, :age_seconds), Tuple{String, Union{Int,Nothing}, Union{String,Nothing}, Bool, Bool, Float64}}[]
+    results = NamedTuple{(:name, :worker_pid, :project, :revise, :is_current, :age_seconds), Tuple{String, Union{Int,Nothing}, Union{String,Nothing}, Bool, Bool, Float64}}[]
 
     for (name, session) in SESSIONS.sessions
         push!(results, (
             name = name,
-            worker_id = worker_pid(session),
+            worker_pid = worker_pid(session),
             project = session.project_path,
             revise = session.revise_loaded,
             is_current = (name == SESSIONS.current),
@@ -140,7 +140,7 @@ function _cleanup_all_workers!()
     # Stop all workers concurrently so total wait stays bounded regardless of
     # session count (Malt.stop escalates exit → SIGTERM → SIGKILL per worker).
     @sync for (_, s) in SESSIONS.sessions
-        if s.worker !== nothing && Malt.isrunning(s.worker)
+        if worker_live(s)
             w = s.worker
             @async try
                 Malt.stop(w; exit_timeout=2.0, term_timeout=2.0)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -228,6 +228,7 @@ Session reset complete.
                 for note in session.worker_notes
                     msg *= "- ⚠ $note\n"
                 end
+                empty!(session.worker_notes)  # consume, like eval — don't repeat on next call
 
                 TextContent(text = msg)
             catch e
@@ -646,7 +647,7 @@ Examples:
                     lines = String["Sessions:"]
                     for s in sessions
                         marker = s.is_current ? " *" : "  "
-                        worker = s.worker_id === nothing ? "not spawned" : "pid $(s.worker_id)"
+                        worker = s.worker_pid === nothing ? "not spawned" : "pid $(s.worker_pid)"
                         project = s.project === nothing ? "default env" : s.project
                         revise = s.revise ? "Revise" : "no Revise"
                         age_min = round(s.age_seconds / 60; digits=1)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -40,6 +40,7 @@ Create the eval tool for evaluating Julia code.
 function create_eval_tool()
     MCPTool(
         name = "eval",
+        title = "Evaluate Julia code",
         description = """
 Evaluate Julia code in a persistent Julia REPL session.
 
@@ -143,11 +144,17 @@ Use `revise(action="revise")` after editing .jl files to hot-reload changes with
 
                 try
                     value_str, output, error_str, elapsed = capture_eval_on_worker(code; timeout=timeout, session_name=session_name, isolated=isolated)
-                    resolved_name = resolve_session(session_name).name
-                    log_interaction(code, value_str, output, error_str; elapsed=elapsed, session_name=resolved_name)
+                    sess = resolve_session(session_name)
+                    log_interaction(code, value_str, output, error_str; elapsed=elapsed, session_name=sess.name)
 
                     result = format_result(code, value_str, output, error_str;
                                             elapsed=elapsed, max_output=max_output, max_stackframes=max_stackframes)
+                    # Surface non-fatal worker-setup warnings (e.g. project activation
+                    # failed, Revise missing) once, then clear so they don't repeat.
+                    if ephemeral_name === nothing && !isempty(sess.worker_notes)
+                        result *= "\n\n⚠ Session notes:\n" * join(("  • " * n for n in sess.worker_notes), "\n")
+                        empty!(sess.worker_notes)
+                    end
                     TextContent(text = result)
                 finally
                     if ephemeral_name !== nothing
@@ -176,6 +183,7 @@ Create the reset tool for resetting the Julia session.
 function create_reset_tool()
     MCPTool(
         name = "reset",
+        title = "Reset Julia session",
         description = """
 Hard reset: Kill the Julia worker process and spawn a fresh one.
 
@@ -202,19 +210,23 @@ Prefer `revise(action="revise")` for function/method changes — it preserves se
                 session_name = get(params, "session", nothing)
                 session = resolve_session(session_name)
 
-                old_id = session.worker_id
-                new_id = reset_worker!(session)
+                old_id = worker_pid(session)
+                reset_worker!(session)
+                new_id = worker_pid(session)
 
                 msg = """
 Session reset complete.
-- Old worker (ID: $old_id) terminated
-- New worker (ID: $new_id) spawned
+- Old worker (pid: $(something(old_id, "none"))) terminated
+- New worker (pid: $(something(new_id, "?"))) spawned
 - All variables, functions, and types cleared
 - Packages will need to be reloaded with `using`
 - Revise.jl: $(session.revise_loaded ? "loaded" : "not available")
 """
                 if session.project_path !== nothing
                     msg *= "- Project re-activated: $(session.project_path)\n"
+                end
+                for note in session.worker_notes
+                    msg *= "- ⚠ $note\n"
                 end
 
                 TextContent(text = msg)
@@ -235,6 +247,7 @@ Create the info tool for getting session information.
 function create_info_tool()
     MCPTool(
         name = "info",
+        title = "Julia session info",
         description = """
 Get information about the current Julia session.
 
@@ -286,6 +299,9 @@ Returns:
                     "Eval Timings ($n evals): $spark  median $(format_elapsed(med)), max $(format_elapsed(mx))\n"
                 end
 
+                notes_str = isempty(session.worker_notes) ? "" :
+                    "Notes:\n" * join(("  ⚠ " * n for n in session.worker_notes), "\n") * "\n"
+
                 msg = """
 Session: $(session.name)$(session.name == SESSIONS.current ? " (current)" : "")
 Julia Version: $(info.version)
@@ -294,8 +310,8 @@ Revise.jl: $(session.revise_loaded ? "loaded" : "not available")
 User Variables:
 $vars_str
 Loaded Modules: $(info.modules)
-Worker ID: $(session.worker_id)
-$(timings_str)"""
+Worker pid: $(something(worker_pid(session), "not yet spawned"))
+$(notes_str)$(timings_str)"""
                 TextContent(text = msg)
             catch e
                 e isa InterruptException && rethrow()
@@ -314,6 +330,7 @@ Create the pkg tool for package management.
 function create_pkg_tool()
     MCPTool(
         name = "pkg",
+        title = "Manage Julia packages",
         description = """
 Manage Julia packages in the current environment.
 
@@ -441,6 +458,7 @@ Create the activate tool for switching projects/environments.
 function create_activate_tool()
     MCPTool(
         name = "activate",
+        title = "Activate Julia project",
         description = """
 Activate a Julia project or environment.
 
@@ -502,6 +520,7 @@ Create the log_viewer tool for controlling the log viewer.
 function create_log_viewer_tool()
     MCPTool(
         name = "log_viewer",
+        title = "Julia log viewer",
         description = """
 Open a separate terminal window showing Julia REPL output in real-time.
 
@@ -561,6 +580,7 @@ Create the session tool for managing multiple Julia REPL sessions.
 function create_session_tool()
     MCPTool(
         name = "session",
+        title = "Manage Julia sessions",
         description = """
 Manage multiple Julia REPL sessions.
 
@@ -612,7 +632,7 @@ Examples:
                 elseif action_lower == "switch"
                     session = switch_session!(name)
                     msg = "Switched to session '$(session.name)'.\n"
-                    msg *= "Worker ID: $(something(session.worker_id, "not yet spawned"))\n"
+                    msg *= "Worker pid: $(something(worker_pid(session), "not yet spawned"))\n"
                     msg *= "Project: $(something(session.project_path, "default"))\n"
                     msg *= "Revise.jl: $(session.revise_loaded ? "loaded" : "not loaded")"
                     TextContent(text = msg)
@@ -626,7 +646,7 @@ Examples:
                     lines = String["Sessions:"]
                     for s in sessions
                         marker = s.is_current ? " *" : "  "
-                        worker = s.worker_id === nothing ? "not spawned" : "worker $(s.worker_id)"
+                        worker = s.worker_id === nothing ? "not spawned" : "pid $(s.worker_id)"
                         project = s.project === nothing ? "default env" : s.project
                         revise = s.revise ? "Revise" : "no Revise"
                         age_min = round(s.age_seconds / 60; digits=1)
@@ -690,6 +710,7 @@ Create the revise tool for hot-reloading Julia code changes.
 function create_revise_tool()
     MCPTool(
         name = "revise",
+        title = "Hot-reload (Revise.jl)",
         description = """
 Hot-reload Julia code changes using Revise.jl — no session restart needed.
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -8,7 +8,7 @@ project environment, and Revise.jl tracking state.
 
 # Fields
 - `name::String`: Session name (e.g., "default", "analysis", "testing") — must not be empty, immutable after construction
-- `worker_id::Union{Int, Nothing}`: Distributed.jl worker process ID
+- `worker::Union{Malt.Worker, Nothing}`: The session's Malt worker (a handle to a separate Julia process), or `nothing` until spawned
 - `project_path::Union{String, Nothing}`: Active project/environment path (persists across resets)
 - `workspace_path::Union{String, Nothing}`: Project directory restored on worker spawn/reset (set by activate, not updated by eval cd() calls)
 - `socket_path::Union{String, Nothing}`: Unix domain socket path for the interactive REPL server
@@ -16,10 +16,11 @@ project environment, and Revise.jl tracking state.
 - `created_at::Float64`: Session creation time (from `time()`)
 - `last_used::Float64`: Last time this session was used (from `time()`)
 - `eval_timings::Vector{Float64}`: Ring buffer of recent eval durations (capped at `MAX_EVAL_TIMINGS`)
+- `worker_notes::Vector{String}`: Non-fatal setup warnings from the current worker spawn (e.g. Revise failed to load, project activation failed) — surfaced in `info` and on the next eval, then cleared
 """
 mutable struct SessionState
     const name::String
-    worker_id::Union{Int, Nothing}
+    worker::Union{Malt.Worker, Nothing}
     project_path::Union{String, Nothing}
     workspace_path::Union{String, Nothing}
     socket_path::Union{String, Nothing}
@@ -27,11 +28,12 @@ mutable struct SessionState
     created_at::Float64
     last_used::Float64
     eval_timings::Vector{Float64}
+    worker_notes::Vector{String}
 
-    function SessionState(name::String, worker_id::Union{Int,Nothing}, project_path::Union{String,Nothing}, revise_loaded::Bool=false)
+    function SessionState(name::String, worker::Union{Malt.Worker,Nothing}, project_path::Union{String,Nothing}, revise_loaded::Bool=false)
         isempty(name) && error("Session name must not be empty")
         now = time()
-        new(name, worker_id, project_path, nothing, nothing, revise_loaded, now, now, Float64[])
+        new(name, worker, project_path, nothing, nothing, revise_loaded, now, now, Float64[], String[])
     end
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,7 +16,7 @@ project environment, and Revise.jl tracking state.
 - `created_at::Float64`: Session creation time (from `time()`)
 - `last_used::Float64`: Last time this session was used (from `time()`)
 - `eval_timings::Vector{Float64}`: Ring buffer of recent eval durations (capped at `MAX_EVAL_TIMINGS`)
-- `worker_notes::Vector{String}`: Non-fatal setup warnings from the current worker spawn (e.g. Revise failed to load, project activation failed) — surfaced in `info` and on the next eval, then cleared
+- `worker_notes::Vector{String}`: Non-fatal setup warnings from the current worker spawn (e.g. Revise failed to load, project activation failed). Consumed (cleared) when surfaced by `eval` or `reset`; `info` peeks without clearing. Reset to empty on every (re)spawn, so notes never leak across worker generations
 """
 mutable struct SessionState
     const name::String

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -1,10 +1,47 @@
-# worker.jl - Distributed worker lifecycle management
+# worker.jl - Malt worker lifecycle management
+
+"""
+    _remote_eval_fetch(w::Malt.Worker, expr) -> Any
+
+Evaluate `expr` in `Main` on worker `w` and return the result. Thin wrapper over
+`Malt.remote_eval_fetch` so every call site uses one spelling of the IPC.
+"""
+_remote_eval_fetch(w::Malt.Worker, expr) = Malt.remote_eval_fetch(Main, w, expr)
+
+"""
+    worker_pid(session::SessionState) -> Union{Int,Nothing}
+
+OS process id of the session's worker, or `nothing` if no worker is running.
+Used for display (Malt workers have no integer cluster id like Distributed).
+"""
+worker_pid(session::SessionState) =
+    session.worker === nothing ? nothing : Int(Base.getpid(session.worker.proc))
+
+"""
+    _one_line(e) -> String
+
+First line of an exception's message, for compact session notes.
+"""
+_one_line(e) = first(split(sprint(showerror, e), '\n'; limit=2))
+
+"""
+    _crash_message(e) -> String
+
+User-facing message for an exception raised while talking to the worker. A
+terminated worker (crash or `exit()`) gets a clear note instead of the raw
+`Malt.TerminatedWorkerException()`.
+"""
+_crash_message(e) =
+    e isa Malt.TerminatedWorkerException ?
+        "Worker process terminated (it crashed or called exit()). A fresh worker will spawn on the next eval." :
+        sprint(showerror, e)
 
 """
     _clear_worker_state!(session::SessionState)
 
 Clear worker-related fields on a session. Centralizes the paired reset of
-`worker_id` and `revise_loaded` so every call site stays consistent.
+`worker`, `revise_loaded`, notes, and the interactive socket so every call site
+stays consistent.
 """
 function _clear_worker_state!(session::SessionState)
     # Clean up socket file from interactive REPL
@@ -16,37 +53,72 @@ function _clear_worker_state!(session::SessionState)
         end
         session.socket_path = nothing
     end
-    session.worker_id = nothing
+    session.worker = nothing
     session.revise_loaded = false
     empty!(session.eval_timings)
+    empty!(session.worker_notes)
 end
 
 """
     _handle_worker_crash!(session::SessionState, e)
 
-Reset session worker state if `e` indicates a dead worker.
-Handles both `ProcessExitedException` and `RemoteException` (when the worker
-is no longer in `workers()`).
+Reset session worker state if `e` indicates a dead worker. Handles
+`Malt.TerminatedWorkerException` and the case where the worker stopped running.
 """
 function _handle_worker_crash!(session::SessionState, e)
-    if e isa Distributed.ProcessExitedException
+    if e isa Malt.TerminatedWorkerException
         _clear_worker_state!(session)
-    elseif session.worker_id !== nothing && !(session.worker_id in workers())
+    elseif session.worker !== nothing && !Malt.isrunning(session.worker)
         _clear_worker_state!(session)
     end
 end
 
 """
-    ensure_worker!(session::SessionState; _retry_without_revise::Bool=false) -> Int
+    _start_output_drain!(session_name::String, w::Malt.Worker)
+
+Drain the worker's stdout/stderr pipes so out-of-band output (async tasks,
+finalizers, background prints that fire outside an eval's capture window) cannot
+fill the pipe buffer and block the worker.
+
+The worker is spawned with `monitor_stdout=false`/`monitor_stderr=false`, so Malt
+does NOT reprint worker output onto the host's stdout — which is the MCP JSON-RPC
+transport. We route drained lines to our own stderr (safe: never the transport),
+where Claude Code collects them in the MCP server log. In-band eval output is
+captured separately by `_with_output_capture` and is unaffected.
+"""
+function _start_output_drain!(session_name::String, w::Malt.Worker)
+    for (pipe, label) in ((w.stdout, "stdout"), (w.stderr, "stderr"))
+        @async begin
+            try
+                while Malt.isrunning(w)
+                    eof(pipe) && break          # blocks until a byte or EOF; no busy-spin
+                    line = readline(pipe)
+                    isempty(line) && continue
+                    try
+                        println(stderr, "[worker:$session_name:$label] ", line)
+                    catch
+                    end
+                end
+            catch
+                # pipe closed / worker gone — drain task exits quietly
+            end
+        end
+    end
+    return nothing
+end
+
+"""
+    ensure_worker!(session::SessionState; _retry_without_revise::Bool=false) -> Malt.Worker
 
 Ensure a worker process exists for the given session, creating one if needed.
-Returns the worker ID. Also attempts to load Revise.jl on the worker.
+Returns the worker. Also attempts to load Revise.jl on the worker.
 
 The `_retry_without_revise` flag is internal — it prevents unbounded recursion
 when Revise.jl consistently crashes the worker process.
 """
 function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false)
-    if session.worker_id === nothing || !(session.worker_id in workers())
+    if session.worker === nothing || !Malt.isrunning(session.worker)
+        empty!(session.worker_notes)
         project_dir = try
             dirname(Pkg.project().path)
         catch e
@@ -54,39 +126,44 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
             e isa OutOfMemoryError && rethrow()
             error("Cannot determine project directory for session '$(session.name)'. Ensure Julia is started with --project=<path>.")
         end
-        new_workers = try
-            addprocs(1; exeflags=`--project=$project_dir`)
+
+        w = try
+            Malt.Worker(; exeflags=["--project=$project_dir"],
+                          monitor_stdout=false, monitor_stderr=false)
         catch e
             error("Failed to spawn worker for session '$(session.name)': $(sprint(showerror, e))")
         end
-        session.worker_id = first(new_workers)
+        session.worker = w
+        _start_output_drain!(session.name, w)
 
-        # Core.eval avoids closure serialization issues with remotecall
+        # Load Pkg — required. A failure here means the worker is unusable.
         try
-            remotecall_fetch(Core.eval, session.worker_id, Main, :(using Pkg))
+            _remote_eval_fetch(w, :(using Pkg))
         catch e
             @warn "Failed to load Pkg on worker, killing half-initialized worker" session=session.name exception=(e, catch_backtrace())
-            orphan_id = session.worker_id
+            try; Malt.stop(w); catch; end
             _clear_worker_state!(session)
-            try; rmprocs(orphan_id); catch; end
             rethrow()
         end
 
+        # Load Revise — optional. Degrade gracefully and record a note.
         if !_retry_without_revise
             try
-                remotecall_fetch(Core.eval, session.worker_id, Main, :(using Revise))
+                _remote_eval_fetch(w, :(using Revise))
                 session.revise_loaded = true
             catch e
                 session.revise_loaded = false
-                if e isa Distributed.RemoteException || e isa Distributed.ProcessExitedException
-                    @warn "Worker may have crashed while loading Revise.jl" session=session.name exception=(e, catch_backtrace())
+                push!(session.worker_notes,
+                    "Revise.jl not loaded ($(_one_line(e))). Hot-reload is disabled; add it with pkg(action=\"add\", packages=\"Revise\").")
+                if e isa Malt.RemoteException
+                    @warn "Could not load Revise.jl on worker" session=session.name
                 else
                     @warn "Unexpected error loading Revise.jl on worker" session=session.name exception=(e, catch_backtrace())
                 end
             end
 
-            # If Revise loading crashed the worker, respawn once without Revise
-            if session.worker_id !== nothing && !(session.worker_id in workers())
+            # If loading Revise crashed the worker, respawn once without Revise.
+            if session.worker !== nothing && !Malt.isrunning(session.worker)
                 _clear_worker_state!(session)
                 return ensure_worker!(session; _retry_without_revise=true)
             end
@@ -95,15 +172,17 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
         if session.project_path !== nothing
             try
                 path = session.project_path
-                remotecall_fetch(Core.eval, session.worker_id, Main, :(Pkg.activate($path)))
+                _remote_eval_fetch(w, :(Pkg.activate($path)))
                 # Sync workspace to project directory if not already set
                 if session.workspace_path === nothing
                     session.workspace_path = session.project_path
                 end
             catch e
-                # Intentionally preserve project_path so a transient activation failure
-                # (e.g., missing Manifest.toml) can succeed on next worker spawn after
-                # the user runs pkg(action="instantiate")
+                # Preserve project_path so a transient activation failure (e.g. missing
+                # Manifest.toml) can succeed on next spawn after pkg(instantiate). Record
+                # a note so the user is not silently left in the wrong environment.
+                push!(session.worker_notes,
+                    "Project activation failed for $(session.project_path) ($(_one_line(e))). Running in the default environment — run pkg(action=\"instantiate\") then reset().")
                 @warn "Failed to activate project on worker — will retry on next worker spawn" project=session.project_path error=e
             end
         end
@@ -112,39 +191,50 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
         if session.workspace_path !== nothing
             try
                 wpath = session.workspace_path
-                remotecall_fetch(Core.eval, session.worker_id, Main, :(cd($wpath)))
+                _remote_eval_fetch(w, :(cd($wpath)))
             catch e
+                push!(session.worker_notes, "Workspace directory $(session.workspace_path) could not be restored; cleared.")
                 @warn "Failed to restore workspace on worker, clearing" workspace=session.workspace_path error=e
                 session.workspace_path = nothing
             end
         end
 
+        # Snapshot the worker's Main symbols AFTER setup. Malt runs its worker event
+        # loop in Main, so its internals (serve, handle, MsgID, …) live there alongside
+        # Pkg/Revise; this baseline lets get_worker_info list only user-defined names.
+        try
+            _remote_eval_fetch(w, :(const _AGENTREPL_BASELINE_NAMES = Set(names(Main; all=true))))
+        catch e
+            @debug "Failed to snapshot baseline names on worker" session=session.name exception=e
+        end
+
         session.last_used = time()
     end
-    return session.worker_id
+    return session.worker
 end
 
 """
     kill_worker!(session::SessionState)
 
-Kill the worker process for the given session.
+Stop the worker process for the given session. `Malt.stop` escalates
+exit → SIGTERM → SIGKILL on its own.
 """
 function kill_worker!(session::SessionState)
-    if session.worker_id !== nothing && session.worker_id in workers()
+    if session.worker !== nothing && Malt.isrunning(session.worker)
         try
-            rmprocs(session.worker_id)
+            Malt.stop(session.worker)
         catch e
-            @warn "Failed to cleanly kill worker, attempting interrupt" session=session.name worker_id=session.worker_id exception=(e, catch_backtrace())
-            try; interrupt(session.worker_id); catch; end
+            @warn "Failed to cleanly stop worker, forcing kill" session=session.name exception=(e, catch_backtrace())
+            try; Malt.kill(session.worker); catch; end
         end
     end
     _clear_worker_state!(session)
 end
 
 """
-    reset_worker!(session::SessionState) -> Int
+    reset_worker!(session::SessionState) -> Malt.Worker
 
-Kill the session's worker and spawn a fresh one. Returns the new worker ID.
+Kill the session's worker and spawn a fresh one. Returns the new worker.
 """
 function reset_worker!(session::SessionState)
     kill_worker!(session)
@@ -186,7 +276,7 @@ end
     capture_eval_on_worker(code::String; timeout=nothing, session_name=nothing, isolated=false) -> (value_str, output, error_str, elapsed)
 
 Evaluate Julia code on the worker process, capturing both return value and printed output.
-Uses Core.eval with expressions to avoid closure serialization issues.
+Uses Malt expression evaluation to avoid closure serialization issues.
 
 Returns a 4-tuple: (value_str, output, error_str, elapsed_seconds).
 
@@ -197,7 +287,7 @@ If `isolated` is true, evaluates in a fresh anonymous module instead of Main (va
 function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=nothing,
                                  session_name::Union{String,Nothing}=nothing, isolated::Bool=false)
     session = resolve_session(session_name)
-    worker_id = ensure_worker!(session)
+    worker = ensure_worker!(session)
     session.last_used = time()
 
     # Pass color preference to worker so repr uses ANSI for color-aware types (UnicodePlots, etc.)
@@ -252,19 +342,19 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
 
     elapsed = @elapsed begin
         if timeout === nothing
-            # No timeout: blocking remotecall_fetch with crash protection
+            # No timeout: blocking remote eval with crash protection
             try
-                value_str, output, error_str = remotecall_fetch(Core.eval, worker_id, Main, eval_expr)
+                value_str, output, error_str = _remote_eval_fetch(worker, eval_expr)
             catch e
                 _handle_worker_crash!(session, e)
                 value_str = "nothing"
                 output = ""
-                error_str = sprint(showerror, e)
+                error_str = _crash_message(e)
             end
         else
-            # With timeout: race remotecall against a cancellable Timer
+            # With timeout: race the remote eval against a cancellable Timer
             result_channel = Channel{Any}(1)
-            future = remotecall(Core.eval, worker_id, Main, eval_expr)
+            future = Malt.remote_eval(Main, worker, eval_expr)
 
             # Timer fires after timeout. Race safety comes from the Channel(1) —
             # only the first put! succeeds. close(timer) is best-effort cleanup.
@@ -294,7 +384,7 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
                 _handle_worker_crash!(session, payload)
                 value_str = "nothing"
                 output = ""
-                error_str = sprint(showerror, payload)
+                error_str = _crash_message(payload)
             else  # :timeout
                 kill_worker!(session)
                 value_str = "nothing"
@@ -316,62 +406,64 @@ end
 Get information about the given session's worker.
 """
 function get_worker_info(session::SessionState)
-    worker_id = ensure_worker!(session)
+    worker = ensure_worker!(session)
 
+    # Wrapped in `let` so these temporaries don't leak into the worker's Main
+    # (which would then show up as bogus "user variables").
     info_expr = quote
-        # Get user-defined symbols with type and size info
-        all_names = names(Main; all=true)
-        protected = Set([:Base, :Core, :Main, :ans, :include, :eval, :Pkg, :Revise])
-        user_vars = NamedTuple{(:name, :type, :size), Tuple{Symbol, String, String}}[]
-        for name in all_names
-            name_str = string(name)
-            if !startswith(name_str, "#") && !startswith(name_str, "_") && !(name in protected)
-                val = try; Core.eval(Main, name); catch; nothing; end
-                type_str = try; string(typeof(val)); catch; "?"; end
-                size_str = try
-                    if applicable(size, val) && !(val isa AbstractString)
-                        s = size(val)
-                        if !isempty(s)
-                            length(s) > 1 ? string(s) : "length=$(length(val))"
+        let
+            all_names = names(Main; all=true)
+            protected = Set([:Base, :Core, :Main, :ans, :include, :eval, :Pkg, :Revise])
+            baseline = isdefined(Main, :_AGENTREPL_BASELINE_NAMES) ? Main._AGENTREPL_BASELINE_NAMES : Set{Symbol}()
+            user_vars = NamedTuple{(:name, :type, :size), Tuple{Symbol, String, String}}[]
+            for name in all_names
+                name_str = string(name)
+                if !startswith(name_str, "#") && !startswith(name_str, "_") && !(name in protected) && !(name in baseline)
+                    val = try; Core.eval(Main, name); catch; nothing; end
+                    type_str = try; string(typeof(val)); catch; "?"; end
+                    size_str = try
+                        if applicable(size, val) && !(val isa AbstractString)
+                            s = size(val)
+                            if !isempty(s)
+                                length(s) > 1 ? string(s) : "length=$(length(val))"
+                            else
+                                ""
+                            end
+                        elseif applicable(length, val)
+                            "length=$(length(val))"
                         else
                             ""
                         end
-                    elseif applicable(length, val)
-                        "length=$(length(val))"
-                    else
+                    catch
                         ""
                     end
-                catch
-                    ""
+                    push!(user_vars, (name=name, type=type_str, size=size_str))
                 end
-                push!(user_vars, (name=name, type=type_str, size=size_str))
             end
-        end
 
-        # Get project path
-        project_path = try
-            dirname(Pkg.project().path)
-        catch
-            "(no project)"
-        end
+            project_path = try
+                dirname(Pkg.project().path)
+            catch
+                "(no project)"
+            end
 
-        # Get loaded modules count
-        loaded_count = try
-            length(keys(Base.loaded_modules))
-        catch
-            0
-        end
+            loaded_count = try
+                length(keys(Base.loaded_modules))
+            catch
+                0
+            end
 
-        (
-            version = string(VERSION),
-            project = project_path,
-            variables = user_vars,
-            modules = loaded_count
-        )
+            (
+                version = string(VERSION),
+                project = project_path,
+                variables = user_vars,
+                modules = loaded_count
+            )
+        end
     end
 
     try
-        return remotecall_fetch(Core.eval, worker_id, Main, info_expr)
+        return _remote_eval_fetch(worker, info_expr)
     catch e
         _handle_worker_crash!(session, e)
         rethrow()

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -18,6 +18,16 @@ worker_pid(session::SessionState) =
     session.worker === nothing ? nothing : Int(Base.getpid(session.worker.proc))
 
 """
+    worker_live(session::SessionState) -> Bool
+
+Whether the session has a worker that is still running. A non-`nothing` `worker`
+may still point at a dead process, so liveness is this two-part check — kept in one
+place rather than re-spelled at every call site.
+"""
+worker_live(session::SessionState) =
+    session.worker !== nothing && Malt.isrunning(session.worker)
+
+"""
     _one_line(e) -> String
 
 First line of an exception's message, for compact session notes.
@@ -25,16 +35,33 @@ First line of an exception's message, for compact session notes.
 _one_line(e) = first(split(sprint(showerror, e), '\n'; limit=2))
 
 """
+    _unwrap(e) -> Exception
+
+Unwrap a `TaskFailedException` (thrown by `fetch` on a failed task) to the
+underlying cause, so worker exceptions are classified by their real type
+(`Malt.TerminatedWorkerException`, `Malt.RemoteException`) rather than the wrapper.
+"""
+_unwrap(e) = e isa TaskFailedException ? e.task.exception : e
+
+"""
     _crash_message(e) -> String
 
-User-facing message for an exception raised while talking to the worker. A
-terminated worker (crash or `exit()`) gets a clear note instead of the raw
-`Malt.TerminatedWorkerException()`.
+User-facing message for an exception raised while talking to the worker.
+Distinguishes the cases so the agent knows whether to fix its code or not:
+- terminated worker (crash or `exit()`) → a clear note, not the raw exception;
+- a remote error from the harness itself (e.g. the result could not be transported)
+  → flagged as a harness issue so it isn't mistaken for a user code error;
+- anything else → the plain rendered error.
 """
-_crash_message(e) =
-    e isa Malt.TerminatedWorkerException ?
-        "Worker process terminated (it crashed or called exit()). A fresh worker will spawn on the next eval." :
-        sprint(showerror, e)
+function _crash_message(e)
+    if e isa Malt.TerminatedWorkerException
+        return "Worker process terminated (it crashed or called exit()). A fresh worker will spawn on the next eval."
+    elseif e isa Malt.RemoteException
+        return "AgentREPL could not run or transport this evaluation (a worker-side harness error, not your code):\n" * sprint(showerror, e)
+    else
+        return sprint(showerror, e)
+    end
+end
 
 """
     _clear_worker_state!(session::SessionState)
@@ -66,9 +93,7 @@ Reset session worker state if `e` indicates a dead worker. Handles
 `Malt.TerminatedWorkerException` and the case where the worker stopped running.
 """
 function _handle_worker_crash!(session::SessionState, e)
-    if e isa Malt.TerminatedWorkerException
-        _clear_worker_state!(session)
-    elseif session.worker !== nothing && !Malt.isrunning(session.worker)
+    if e isa Malt.TerminatedWorkerException || (session.worker !== nothing && !worker_live(session))
         _clear_worker_state!(session)
     end
 end
@@ -91,7 +116,7 @@ function _start_output_drain!(session_name::String, w::Malt.Worker)
         @async begin
             try
                 while Malt.isrunning(w)
-                    eof(pipe) && break          # blocks until a byte or EOF; no busy-spin
+                    eof(pipe) && break          # blocks until a byte or EOF; clean close exits
                     line = readline(pipe)
                     isempty(line) && continue
                     try
@@ -99,8 +124,16 @@ function _start_output_drain!(session_name::String, w::Malt.Worker)
                     catch
                     end
                 end
-            catch
-                # pipe closed / worker gone — drain task exits quietly
+            catch e
+                # A clean EOF leaves the loop above; reaching here means an unexpected
+                # read error while the worker is still up. Leave a breadcrumb — a
+                # silently dead drain is what lets the pipe fill and wedge the worker.
+                if Malt.isrunning(w)
+                    try
+                        println(stderr, "[worker:$session_name:$label] drain stopped on error: ", sprint(showerror, e))
+                    catch
+                    end
+                end
             end
         end
     end
@@ -113,11 +146,16 @@ end
 Ensure a worker process exists for the given session, creating one if needed.
 Returns the worker. Also attempts to load Revise.jl on the worker.
 
+The returned worker was alive at return time. A remote-eval failure during the
+post-spawn setup (project activation, workspace cd) is recorded as a note and can
+leave the worker freshly dead, so callers should treat a `TerminatedWorkerException`
+on first use as possible and route it through `_handle_worker_crash!`.
+
 The `_retry_without_revise` flag is internal — it prevents unbounded recursion
 when Revise.jl consistently crashes the worker process.
 """
 function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false)
-    if session.worker === nothing || !Malt.isrunning(session.worker)
+    if !worker_live(session)
         empty!(session.worker_notes)
         project_dir = try
             dirname(Pkg.project().path)
@@ -163,9 +201,12 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
             end
 
             # If loading Revise crashed the worker, respawn once without Revise.
-            if session.worker !== nothing && !Malt.isrunning(session.worker)
+            if !worker_live(session)
                 _clear_worker_state!(session)
-                return ensure_worker!(session; _retry_without_revise=true)
+                w2 = ensure_worker!(session; _retry_without_revise=true)
+                push!(session.worker_notes,
+                    "Loading Revise.jl crashed the worker; respawned without it. Hot-reload is disabled.")
+                return w2
             end
         end
 
@@ -205,7 +246,10 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
         try
             _remote_eval_fetch(w, :(const _AGENTREPL_BASELINE_NAMES = Set(names(Main; all=true))))
         catch e
-            @debug "Failed to snapshot baseline names on worker" session=session.name exception=e
+            # Without the baseline, get_worker_info would list Malt/Pkg internals as
+            # "user variables". Surface the degraded state instead of hiding it.
+            @warn "Could not snapshot Main baseline on worker; variable listing may include internals" session=session.name exception=(e, catch_backtrace())
+            push!(session.worker_notes, "Variable listing may include internal symbols (baseline snapshot failed).")
         end
 
         session.last_used = time()
@@ -220,7 +264,7 @@ Stop the worker process for the given session. `Malt.stop` escalates
 exit → SIGTERM → SIGKILL on its own.
 """
 function kill_worker!(session::SessionState)
-    if session.worker !== nothing && Malt.isrunning(session.worker)
+    if worker_live(session)
         try
             Malt.stop(session.worker)
         catch e
@@ -330,7 +374,9 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
                 try
                     string(_eval_value)
                 catch str_err
-                    "<$(typeof(_eval_value))>"
+                    # Both show and string threw — surface that display failed (often a
+                    # bug in the value's own show method) instead of an opaque placeholder.
+                    "<$(typeof(_eval_value)): display threw $(typeof(str_err))>"
                 end
             end
 
@@ -368,14 +414,27 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
                     isopen(result_channel) && put!(result_channel, (:ok, result))
                 catch e
                     try
-                        isopen(result_channel) && put!(result_channel, (:error, e))
-                    catch
+                        isopen(result_channel) && put!(result_channel, (:error, _unwrap(e)))
+                    catch put_err
+                        @debug "timeout-race: result task could not deliver (channel closed)" exception=put_err
                     end
                 end
             end
 
             tag, payload = take!(result_channel)
             close(timer)
+            # Resolve the boundary race: if the eval actually finished right as the
+            # timer fired, prefer the real outcome over reporting a timeout (a crash
+            # at the deadline must not be mislabeled "your code ran too long").
+            if tag == :timeout && istaskdone(future)
+                try
+                    payload = fetch(future)
+                    tag = :ok
+                catch e
+                    payload = _unwrap(e)
+                    tag = :error
+                end
+            end
             close(result_channel)
 
             if tag == :ok

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using Aqua
     include("test_sessions.jl")
     include("test_competitive_features.jl")
     include("test_revise.jl")
+    include("test_resources.jl")
 
     # MCP protocol integration tests (spawn server subprocess, ~60s)
     # Run with: AGENTREPL_E2E=true julia --project=. -e "using Pkg; Pkg.test()"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Test
 using AgentREPL
-using Distributed
 using Aqua
 
 @testset "AgentREPL.jl" begin

--- a/test/test_eval.jl
+++ b/test/test_eval.jl
@@ -87,7 +87,7 @@ end
         @test elapsed >= 1.0
         # Worker should have been killed
         session = AgentREPL.get_current_session!()
-        @test session.worker_id === nothing
+        @test session.worker === nothing
     end
 
     @testset "Next eval after timeout spawns fresh worker" begin
@@ -96,7 +96,7 @@ end
         @test error_str === nothing
         @test value_str == "42"
         session = AgentREPL.get_current_session!()
-        @test session.worker_id !== nothing
+        @test session.worker !== nothing
     end
 
     @testset "No timeout when code completes fast" begin
@@ -256,9 +256,10 @@ end
 
         # Reset the worker
         session = AgentREPL.get_current_session!()
-        old_id = session.worker_id
-        new_id = AgentREPL.reset_worker!(session)
-        @test new_id != old_id
+        old_pid = AgentREPL.worker_pid(session)
+        AgentREPL.reset_worker!(session)
+        new_pid = AgentREPL.worker_pid(session)
+        @test new_pid != old_pid
 
         # Variable should no longer exist
         _, _, error_str, _ = AgentREPL.capture_eval_on_worker("reset_test_var")
@@ -286,13 +287,13 @@ end
         # Ensure we have a worker
         session = AgentREPL.get_current_session!()
         AgentREPL.ensure_worker!(session)
-        @test session.worker_id !== nothing
+        @test session.worker !== nothing
 
         # exit() should crash the worker
         value_str, output, error_str, elapsed = AgentREPL.capture_eval_on_worker("exit()")
         @test error_str !== nothing
-        @test contains(error_str, "crashed") || contains(error_str, "ProcessExitedException")
-        @test session.worker_id === nothing
+        @test contains(error_str, "terminated") || contains(error_str, "crashed")
+        @test session.worker === nothing
         @test session.revise_loaded == false
     end
 
@@ -302,7 +303,7 @@ end
         @test error_str === nothing
         @test value_str == "42"
         session = AgentREPL.get_current_session!()
-        @test session.worker_id !== nothing
+        @test session.worker !== nothing
     end
 end
 
@@ -346,13 +347,13 @@ end
         AgentREPL.create_session!("cleanup-test")
         AgentREPL.capture_eval_on_worker("1+1"; session_name="cleanup-test")
         session = AgentREPL.SESSIONS.sessions["cleanup-test"]
-        worker_id = session.worker_id
-        @test worker_id !== nothing
-        @test worker_id in Distributed.workers()
+        worker = session.worker
+        @test worker !== nothing
+        @test AgentREPL.Malt.isrunning(worker)
 
         AgentREPL._cleanup_all_workers!()
 
-        @test !(worker_id in Distributed.workers())
+        @test !AgentREPL.Malt.isrunning(worker)
         # Clean up session registry
         try; AgentREPL.destroy_session!("cleanup-test"); catch; end
     end
@@ -477,5 +478,5 @@ end
 @testset "Cleanup" begin
     session = AgentREPL.get_current_session!()
     AgentREPL.kill_worker!(session)
-    @test session.worker_id === nothing
+    @test session.worker === nothing
 end

--- a/test/test_eval.jl
+++ b/test/test_eval.jl
@@ -305,6 +305,57 @@ end
         session = AgentREPL.get_current_session!()
         @test session.worker !== nothing
     end
+
+    @testset "Crash during a timed eval (timeout :error branch)" begin
+        # A worker that dies WITH a timeout set must be reported as a crash, not a
+        # timeout. This exercises the :error branch of the timeout race, distinct
+        # from the no-timeout path and the :timeout path.
+        session = AgentREPL.get_current_session!()
+        AgentREPL.ensure_worker!(session)
+        @test session.worker !== nothing
+        _, _, error_str, _ = AgentREPL.capture_eval_on_worker("exit()"; timeout=30.0)
+        @test error_str !== nothing
+        @test contains(error_str, "terminated") || contains(error_str, "crashed")
+        @test !contains(error_str, "TimeoutError")
+        @test session.worker === nothing
+    end
+end
+
+@testset "Worker Notes" begin
+    @testset "eval surfaces a note once, then consumes it" begin
+        session = AgentREPL.get_current_session!()
+        AgentREPL.ensure_worker!(session)
+        push!(session.worker_notes, "synthetic-note-xyz")
+        tool = AgentREPL.create_eval_tool()
+        r = tool.handler(Dict("code" => "1+1"))
+        text = r isa AgentREPL.TextContent ? r.text : r.content[1]["text"]
+        @test occursin("synthetic-note-xyz", text)   # surfaced in the eval result
+        @test isempty(session.worker_notes)           # then cleared
+
+        # A subsequent eval no longer repeats it.
+        r2 = tool.handler(Dict("code" => "2+2"))
+        text2 = r2 isa AgentREPL.TextContent ? r2.text : r2.content[1]["text"]
+        @test !occursin("synthetic-note-xyz", text2)
+    end
+
+    @testset "info peeks a note without consuming it" begin
+        session = AgentREPL.get_current_session!()
+        AgentREPL.ensure_worker!(session)
+        push!(session.worker_notes, "peek-note-abc")
+        r = AgentREPL.create_info_tool().handler(Dict())
+        text = r isa AgentREPL.TextContent ? r.text : r.content[1]["text"]
+        @test occursin("peek-note-abc", text)
+        @test !isempty(session.worker_notes)          # info does not consume
+        empty!(session.worker_notes)
+    end
+
+    @testset "notes do not leak across a respawn" begin
+        session = AgentREPL.get_current_session!()
+        AgentREPL.ensure_worker!(session)
+        push!(session.worker_notes, "stale-note-should-vanish")
+        AgentREPL.reset_worker!(session)              # clears notes on (re)spawn
+        @test !any(n -> occursin("stale-note-should-vanish", n), session.worker_notes)
+    end
 end
 
 @testset "Project Activation" begin

--- a/test/test_mcp_protocol.jl
+++ b/test/test_mcp_protocol.jl
@@ -83,25 +83,31 @@ function send_notification!(client::MCPClient, method::String, params::Dict=Dict
     flush(client.input)
 end
 
-function recv_response(client::MCPClient; timeout::Float64=60.0)
+function recv_response(client::MCPClient; timeout::Float64=60.0, id::Union{Int,Nothing}=nothing)
     deadline = time() + timeout
     while true
         remaining = deadline - time()
-        remaining <= 0 && error("Timeout ($(timeout)s) reading from MCP server")
+        remaining <= 0 && error("Timeout ($(timeout)s) waiting for response id=$(id)")
 
         line = _next_line(client, remaining)
-        line === nothing && error("Timeout ($(timeout)s) or EOF reading from MCP server")
+        line === nothing && error("Timeout ($(timeout)s) or EOF waiting for response id=$(id)")
 
         # Skip any non-JSON line (defensive — the transport should be clean JSON).
         startswith(strip(line), "{") || continue
-        return JSON3.read(line, Dict{String,Any})
+        msg = JSON3.read(line, Dict{String,Any})
+        # When an id is given, skip notifications and responses for other requests.
+        # This keeps one slow call (whose response arrives after its timeout) from
+        # desyncing the stream and poisoning every later call.
+        if id !== nothing
+            (haskey(msg, "id") && msg["id"] == id) || continue
+        end
+        return msg
     end
 end
 
 function call_tool!(client::MCPClient, name::String, arguments::Dict=Dict(); timeout::Float64=60.0)
-    send_request!(client, "tools/call", Dict("name" => name, "arguments" => arguments))
-    resp = recv_response(client; timeout=timeout)
-    return resp
+    id = send_request!(client, "tools/call", Dict("name" => name, "arguments" => arguments))
+    return recv_response(client; timeout=timeout, id=id)
 end
 
 function get_tool_text(resp)
@@ -143,12 +149,14 @@ end
     try
         # --- Initialize handshake ---
         @testset "Initialize handshake" begin
-            send_request!(client, "initialize", Dict(
+            id = send_request!(client, "initialize", Dict(
                 "capabilities" => Dict(),
                 "clientInfo" => Dict("name" => "test-client", "version" => "1.0"),
                 "protocolVersion" => "2025-06-18"
             ))
-            resp = recv_response(client; timeout=30.0)
+            # Generous: the server subprocess cold-starts (loads the package + deps)
+            # before it can answer, which is slow on CI runners.
+            resp = recv_response(client; timeout=180.0, id=id)
             @test haskey(resp, "result")
             @test resp["result"]["serverInfo"]["name"] == "julia-repl"
             @test haskey(resp["result"], "protocolVersion")
@@ -165,8 +173,8 @@ end
 
         # --- List tools ---
         @testset "List tools" begin
-            send_request!(client, "tools/list", Dict())
-            resp = recv_response(client; timeout=10.0)
+            id = send_request!(client, "tools/list", Dict())
+            resp = recv_response(client; timeout=30.0, id=id)
             tools = resp["result"]["tools"]
             tool_names = Set([t["name"] for t in tools])
             expected = Set(["eval", "reset", "info", "pkg", "activate", "log_viewer", "session", "revise"])
@@ -274,8 +282,8 @@ end
 
         # --- resources ---
         @testset "resources - list" begin
-            send_request!(client, "resources/list", Dict())
-            resp = recv_response(client; timeout=10.0)
+            id = send_request!(client, "resources/list", Dict())
+            resp = recv_response(client; timeout=30.0, id=id)
             uris = Set([r["uri"] for r in resp["result"]["resources"]])
             @test "agentrepl://session/info" in uris
             @test "agentrepl://session/variables" in uris
@@ -283,8 +291,8 @@ end
         end
 
         @testset "resources - read info" begin
-            send_request!(client, "resources/read", Dict("uri" => "agentrepl://session/info"))
-            resp = recv_response(client; timeout=60.0)
+            id = send_request!(client, "resources/read", Dict("uri" => "agentrepl://session/info"))
+            resp = recv_response(client; timeout=60.0, id=id)
             contents = resp["result"]["contents"]
             @test !isempty(contents)
             payload = JSON3.read(contents[1]["text"], Dict{String,Any})

--- a/test/test_mcp_protocol.jl
+++ b/test/test_mcp_protocol.jl
@@ -18,29 +18,42 @@ const JULIA_EXE = Base.julia_cmd().exec[1]
 
 mutable struct MCPClient
     proc::Base.Process
-    input::IO              # write to server stdin
-    output::IO             # read from server stdout
+    input::IO                 # write to server stdin
+    output::IO                # read from server stdout
     next_id::Int
-    lines::Channel{String} # every stdout line, fed by one background reader
+    lines::Channel{String}    # every stdout line, fed by one background reader
+    errlines::Channel{String} # every stderr line (server logs + drained worker output)
+end
+
+# One reader per stream owns it. Consumers poll the channels; nothing else calls
+# readline, so no dangling reader can steal another consumer's line.
+function _spawn_reader(io, ch)
+    @async begin
+        try
+            for line in eachline(io)
+                put!(ch, line)
+            end
+        catch
+        finally
+            try; close(ch); catch; end
+        end
+    end
 end
 
 function start_server()
     cmd = `$JULIA_EXE --project=$PROJECT_DIR $SERVER_SCRIPT`
-    proc = open(cmd, "r+")
+    # Explicit pipes (not `open(cmd, "r+")`) so we can capture stderr separately and
+    # verify worker output is routed there rather than onto the stdout transport.
+    inp = Pipe(); outp = Pipe(); errp = Pipe()
+    proc = run(pipeline(cmd; stdin=inp, stdout=outp, stderr=errp); wait=false)
+    close(inp.out); close(outp.in); close(errp.in)
     lines = Channel{String}(10_000)
-    client = MCPClient(proc, proc, proc, 1, lines)
-    # A SINGLE reader owns the stream. Consumers poll the channel; nothing else
-    # calls readline, so no dangling reader can steal another consumer's line.
-    @async begin
-        try
-            for line in eachline(proc)
-                put!(lines, line)
-            end
-        catch
-        finally
-            try; close(lines); catch; end
-        end
-    end
+    # Large cap: the server's stderr accumulates across the whole session; it must not
+    # fill and block the reader before a later test drains it.
+    errlines = Channel{String}(200_000)
+    client = MCPClient(proc, inp, outp, 1, lines, errlines)
+    _spawn_reader(outp, lines)
+    _spawn_reader(errp, errlines)
     return client
 end
 
@@ -119,11 +132,21 @@ end
 # Collect everything the server emits on stdout over `idle` seconds. Used to assert
 # the JSON-RPC transport never carries stray (non-JSON) output.
 function drain_stdout_lines(client::MCPClient; idle::Float64=3.0)
+    return _drain(client.lines; idle=idle)
+end
+
+# Collect the server's stderr (its own logs plus worker output drained to stderr)
+# over `idle` seconds. Used to prove worker out-of-band output lands on stderr.
+function drain_stderr_lines(client::MCPClient; idle::Float64=3.0)
+    return _drain(client.errlines; idle=idle)
+end
+
+function _drain(ch::Channel{String}; idle::Float64=3.0)
     lines = String[]
     deadline = time() + idle
     while time() < deadline
-        if isready(client.lines)
-            line = take!(client.lines)
+        if isready(ch)
+            line = take!(ch)
             isempty(line) || push!(lines, line)
         else
             sleep(0.05)
@@ -314,6 +337,13 @@ end
                 @test JSON3.read(line, Dict{String,Any}) isa Dict  # every line is valid JSON-RPC
             end
             @test !any(l -> occursin("LEAK", l), extra)         # marker never hit the transport
+
+            # The marker MUST instead surface on the server's stderr. This proves the
+            # drain actually ran and routed worker output away from the transport —
+            # not merely that Malt's monitor flags are off. Without this assertion the
+            # stdout check could pass even if draining were broken.
+            errs = drain_stderr_lines(client; idle=3.0)
+            @test any(l -> occursin("{LEAK", l), errs)
 
             # transport still intact afterwards
             resp2 = call_tool!(client, "eval", Dict("code" => "2+2"); timeout=30.0)

--- a/test/test_mcp_protocol.jl
+++ b/test/test_mcp_protocol.jl
@@ -18,15 +18,45 @@ const JULIA_EXE = Base.julia_cmd().exec[1]
 
 mutable struct MCPClient
     proc::Base.Process
-    input::IO   # write to server stdin
-    output::IO  # read from server stdout
+    input::IO              # write to server stdin
+    output::IO             # read from server stdout
     next_id::Int
+    lines::Channel{String} # every stdout line, fed by one background reader
 end
 
 function start_server()
     cmd = `$JULIA_EXE --project=$PROJECT_DIR $SERVER_SCRIPT`
     proc = open(cmd, "r+")
-    MCPClient(proc, proc, proc, 1)
+    lines = Channel{String}(10_000)
+    client = MCPClient(proc, proc, proc, 1, lines)
+    # A SINGLE reader owns the stream. Consumers poll the channel; nothing else
+    # calls readline, so no dangling reader can steal another consumer's line.
+    @async begin
+        try
+            for line in eachline(proc)
+                put!(lines, line)
+            end
+        catch
+        finally
+            try; close(lines); catch; end
+        end
+    end
+    return client
+end
+
+# Take the next line from the reader channel within `timeout`, or `nothing`.
+# Polls with `isready` so it never leaves a blocked `take!` behind.
+function _next_line(client::MCPClient, timeout::Float64)
+    deadline = time() + timeout
+    while time() < deadline
+        if isready(client.lines)
+            return take!(client.lines)
+        elseif !isopen(client.lines)
+            return nothing  # reader finished (server EOF) and nothing buffered
+        end
+        sleep(0.02)
+    end
+    return nothing
 end
 
 function send_request!(client::MCPClient, method::String, params::Dict=Dict())
@@ -59,30 +89,12 @@ function recv_response(client::MCPClient; timeout::Float64=60.0)
         remaining = deadline - time()
         remaining <= 0 && error("Timeout ($(timeout)s) reading from MCP server")
 
-        ch = Channel{String}(1)
-        @async begin
-            try
-                line = readline(client.output)
-                put!(ch, line)
-            catch e
-                try; put!(ch, ""); catch; end
-            end
-        end
-        timer = Timer(remaining) do _
-            try; put!(ch, ""); catch; end
-        end
-        line = take!(ch)
-        close(timer)
-        close(ch)
+        line = _next_line(client, remaining)
+        line === nothing && error("Timeout ($(timeout)s) or EOF reading from MCP server")
 
-        isempty(line) && error("Timeout ($(timeout)s) or EOF reading from MCP server")
-
-        # Skip non-JSON lines (e.g., "From worker N:" messages from Distributed.jl)
-        stripped = strip(line)
-        if startswith(stripped, "{")
-            return JSON3.read(line, Dict{String,Any})
-        end
-        # else: skip this line and read the next one
+        # Skip any non-JSON line (defensive — the transport should be clean JSON).
+        startswith(strip(line), "{") || continue
+        return JSON3.read(line, Dict{String,Any})
     end
 end
 
@@ -96,6 +108,22 @@ function get_tool_text(resp)
     result = resp["result"]
     content = result["content"]
     return content[1]["text"]
+end
+
+# Collect everything the server emits on stdout over `idle` seconds. Used to assert
+# the JSON-RPC transport never carries stray (non-JSON) output.
+function drain_stdout_lines(client::MCPClient; idle::Float64=3.0)
+    lines = String[]
+    deadline = time() + idle
+    while time() < deadline
+        if isready(client.lines)
+            line = take!(client.lines)
+            isempty(line) || push!(lines, line)
+        else
+            sleep(0.05)
+        end
+    end
+    return lines
 end
 
 function shutdown!(client::MCPClient)
@@ -125,6 +153,12 @@ end
             @test resp["result"]["serverInfo"]["name"] == "julia-repl"
             @test haskey(resp["result"], "protocolVersion")
 
+            # Advertise only what we implement: tools + resources, not prompts (B1)
+            caps = resp["result"]["capabilities"]
+            @test haskey(caps, "tools")
+            @test haskey(caps, "resources")
+            @test !haskey(caps, "prompts")
+
             # Send initialized notification
             send_notification!(client, "notifications/initialized")
         end
@@ -133,9 +167,12 @@ end
         @testset "List tools" begin
             send_request!(client, "tools/list", Dict())
             resp = recv_response(client; timeout=10.0)
-            tool_names = Set([t["name"] for t in resp["result"]["tools"]])
+            tools = resp["result"]["tools"]
+            tool_names = Set([t["name"] for t in tools])
             expected = Set(["eval", "reset", "info", "pkg", "activate", "log_viewer", "session", "revise"])
             @test tool_names == expected
+            # Every tool carries a human-friendly title (B3)
+            @test all(haskey(t, "title") && !isempty(t["title"]) for t in tools)
         end
 
         # --- eval tool ---
@@ -234,6 +271,46 @@ end
         # Skip log_viewer tests: mode="file" and mode="auto" open terminal windows
         # which have visual side effects inappropriate for automated testing.
         # The log_viewer tool is tested manually.
+
+        # --- resources ---
+        @testset "resources - list" begin
+            send_request!(client, "resources/list", Dict())
+            resp = recv_response(client; timeout=10.0)
+            uris = Set([r["uri"] for r in resp["result"]["resources"]])
+            @test "agentrepl://session/info" in uris
+            @test "agentrepl://session/variables" in uris
+            @test "agentrepl://sessions" in uris
+        end
+
+        @testset "resources - read info" begin
+            send_request!(client, "resources/read", Dict("uri" => "agentrepl://session/info"))
+            resp = recv_response(client; timeout=60.0)
+            contents = resp["result"]["contents"]
+            @test !isempty(contents)
+            payload = JSON3.read(contents[1]["text"], Dict{String,Any})
+            @test haskey(payload, "julia_version")
+            @test haskey(payload, "worker_pid")
+        end
+
+        # --- transport stays clean JSON even when a worker prints out of band ---
+        @testset "Transport stream cleanliness" begin
+            # marker bytes "{LEAK" — built at runtime, so it cannot appear in the
+            # echoed source. It fires ~1s later, outside the eval capture window.
+            code = "@async (sleep(1.0); println(String(UInt8[123,76,69,65,75]))); 7"
+            resp = call_tool!(client, "eval", Dict("code" => code); timeout=90.0)
+            @test occursin("7", get_tool_text(resp))
+
+            extra = drain_stdout_lines(client; idle=3.0)  # window for the async print
+            for line in extra
+                @test startswith(strip(line), "{")              # never raw worker output
+                @test JSON3.read(line, Dict{String,Any}) isa Dict  # every line is valid JSON-RPC
+            end
+            @test !any(l -> occursin("LEAK", l), extra)         # marker never hit the transport
+
+            # transport still intact afterwards
+            resp2 = call_tool!(client, "eval", Dict("code" => "2+2"); timeout=30.0)
+            @test occursin("4", get_tool_text(resp2))
+        end
 
         # --- reset tool (run last since it kills the worker) ---
         @testset "reset" begin

--- a/test/test_resources.jl
+++ b/test/test_resources.jl
@@ -1,0 +1,123 @@
+using Test
+using AgentREPL
+const A = AgentREPL
+
+# Drop all sessions so we start from a clean, worker-free registry.
+function _reset_sessions!()
+    for name in collect(keys(A.SESSIONS.sessions))
+        try; A.destroy_session!(name); catch; end
+    end
+    A.SESSIONS.current = nothing
+end
+
+@testset "MCP Resources" begin
+    _reset_sessions!()
+
+    @testset "_resource_safe ok/error discriminant" begin
+        ok = A._resource_safe(() -> (a = 1, b = "x"))
+        @test ok.ok == true
+        @test ok.a == 1 && ok.b == "x"
+
+        bad = A._resource_safe(() -> error("boom"))
+        @test bad.ok == false
+        @test occursin("boom", bad.error)
+
+        # Cancellation / OOM must propagate, never be flattened into `error`.
+        @test_throws InterruptException A._resource_safe(() -> throw(InterruptException()))
+    end
+
+    @testset "reads never spawn a worker" begin
+        _reset_sessions!()
+        s = A.get_current_session!()          # "default", no worker yet
+        @test A.worker_live(s) == false
+
+        info = A._resource_info()
+        @test info.ok && info.worker_spawned == false && info.worker_pid === nothing
+        @test info.julia_version == string(VERSION)
+
+        vars = A._resource_variables()
+        @test vars.ok && vars.worker_spawned == false && isempty(vars.variables)
+
+        proj = A._resource_project()
+        @test proj.ok && haskey(proj, :project_dir) && haskey(proj, :manifest_present)
+
+        @test A.worker_live(s) == false        # none of the reads spawned a worker
+    end
+
+    @testset "reads reflect a live worker" begin
+        _reset_sessions!()
+        s = A.get_current_session!()
+        A.capture_eval_on_worker("res_var = 123")
+        @test A.worker_live(s)
+
+        info = A._resource_info()
+        @test info.worker_spawned == true && info.worker_pid isa Int
+        @test info.loaded_modules > 0
+
+        vars = A._resource_variables()
+        @test any(v -> v.name == "res_var", vars.variables)
+
+        sess = A._resource_sessions()
+        @test sess.ok
+        @test any(row -> row.name == s.name && row.worker_pid isa Int, sess.sessions)
+        # field names unified with info: rows carry `revise_loaded`, not `revise`
+        @test all(haskey(row, :revise_loaded) for row in sess.sessions)
+    end
+
+    @testset "project resource shape" begin
+        proj = A._resource_project()
+        @test proj.ok
+        @test haskey(proj, :project_dir)
+        @test haskey(proj, :project_toml)
+        @test haskey(proj, :manifest_present)
+    end
+
+    @testset "log resource: audit disabled vs enabled + tail cap" begin
+        A.close_audit_logs!()                 # clear any handles left by other suites
+        @test A._AUDIT_DIR[] === nothing
+        disabled = A._resource_log()
+        @test disabled.ok && disabled.audit_enabled == false
+
+        mktempdir() do dir
+            old = A._AUDIT_DIR[]
+            try
+                A.close_audit_logs!()
+                A._AUDIT_DIR[] = dir
+                s = A.get_current_session!()
+
+                empty_log = A._resource_log()
+                @test empty_log.audit_enabled == true && isempty(empty_log.tail)
+
+                for i in 1:5
+                    A.audit_interaction(s.name, "x=$i", "$i", "", nothing; elapsed=0.001)
+                end
+                got = A._resource_log()
+                @test got.audit_enabled == true && !isempty(got.tail)
+
+                # Each interaction writes several lines; 250 of them blows past the
+                # 200-line tail cap, so the resource returns exactly the last 200.
+                for i in 1:250
+                    A.audit_interaction(s.name, "y=$i", "$i", "", nothing)
+                end
+                big = A._resource_log()
+                @test length(big.tail) == 200
+            finally
+                A.close_audit_logs!()
+                A._AUDIT_DIR[] = old
+            end
+        end
+    end
+
+    @testset "agentrepl_resources registers the five resources" begin
+        rs = A.agentrepl_resources()
+        uris = Set(string(r.uri) for r in rs)
+        @test length(rs) == 5
+        for u in ("agentrepl://sessions", "agentrepl://session/variables",
+                  "agentrepl://session/info", "agentrepl://session/project",
+                  "agentrepl://session/log")
+            @test u in uris
+        end
+    end
+
+    _reset_sessions!()
+end

--- a/test/test_revise.jl
+++ b/test/test_revise.jl
@@ -7,7 +7,7 @@
     @testset "is_revise_available with no worker" begin
         session = AgentREPL.create_session!("revise-test")
         # No worker spawned yet
-        @test session.worker_id === nothing
+        @test session.worker === nothing
         @test !AgentREPL.is_revise_available(session)
     end
 

--- a/test/test_sessions.jl
+++ b/test/test_sessions.jl
@@ -14,7 +14,7 @@ end
     @testset "Default session auto-creation" begin
         session = AgentREPL.get_current_session!()
         @test session.name == "default"
-        @test session.worker_id === nothing  # Lazy spawning
+        @test session.worker === nothing  # Lazy spawning
         @test AgentREPL.SESSIONS.current == "default"
     end
 
@@ -100,7 +100,7 @@ end
         # Create a session and eval something to spawn worker
         AgentREPL.create_session!("doomed")
         AgentREPL.capture_eval_on_worker("x = 1")
-        doomed_worker = AgentREPL.SESSIONS.sessions["doomed"].worker_id
+        doomed_worker = AgentREPL.SESSIONS.sessions["doomed"].worker
         @test doomed_worker !== nothing
 
         # Switch away and destroy


### PR DESCRIPTION
## Summary

Replaces the Distributed.jl worker layer with [Malt.jl](https://github.com/JuliaPluto/Malt.jl) (Pluto's isolated-worker library) and adds a round of MCP hardening and deeper Claude Code integration.

**Why Malt.** Malt spawns workers with `monitor_stdout=false`/`monitor_stderr=false`, so each worker's output stays on a private pipe (drained to the server's stderr) and can **never** reach the main process's stdout — which is the MCP JSON-RPC transport. On Distributed, worker output forwarded toward the manager's streams was a latent way to corrupt the transport (the old code only redirected output *during* the eval window; async/finalizer/startup prints were uncovered). Malt also removes Distributed's global cluster state and replaces hand-rolled lifecycle/crash logic with `stop` (exit→SIGTERM→SIGKILL), `isrunning`, `interrupt`, and `TerminatedWorkerException`.

## What's in here

- **Malt worker backend.** `SessionState.worker` is now a `Malt.Worker`; `info`/`session` report the worker OS pid. Per-worker stdout/stderr drain task. Distributed dropped from deps.
- **MCP resources** — `agentrepl://sessions`, `session/variables`, `session/info`, `session/project`, `session/log` — so a client can pull session state into context without an extra `eval`/`info` call.
- **Capability fix** — declare only Tools + Resources, instead of the framework default that advertised resource subscriptions and prompts the server doesn't implement.
- **Failure surfacing** — Revise-load / project-activation failures now show up in `info` and the next eval result (`worker_notes`), not just stderr.
- **Tool titles** on all eight tools.
- **Cleaner `info`** — baseline-snapshot of `Main` symbols at spawn so Malt's worker-loop globals don't appear as user variables.
- **Tests/CI** — transport-cleanliness regression test (asserts worker output never reaches the JSON-RPC stream) + a dedicated E2E job (`AGENTREPL_E2E=true`, Julia 1.12).
- Doc sync across README/CLAUDE.md/CHANGELOG/CONTRIBUTING/plugin.

Also adds the `run-agentrepl` skill (second commit) — a driver + SKILL.md to launch and drive the server.

## Not included (framework gap)

Tool annotations (`readOnlyHint`/`destructiveHint`) and structured tool output aren't possible on the current ModelContextProtocol.jl — `MCPTool` has no `annotations`/`output_schema` field and `handle_list_tools` wouldn't serialize one. Tracked separately; titles are the serialized subset available today.

## Test plan

```
julia --project=. -e "using Pkg; Pkg.test()"                    # 268 unit
AGENTREPL_E2E=true julia --project=. -e "using Pkg; Pkg.test()" # + 35 protocol = 303
```
All green on Julia 1.12.6.

## Note for reviewers

The `docs/sync-claude-md-readme` branch also edits CLAUDE.md/README; whichever merges second needs a small conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)