### PR TITLE
Fix Revise hot-reload for activated projects

### DIFF
--- a/src/worker.jl
+++ b/src/worker.jl
@@ -32,7 +32,18 @@ worker_live(session::SessionState) =
 
 First line of an exception's message, for compact session notes.
 """
-_one_line(e) = first(split(sprint(showerror, e), '\n'; limit=2))
+function _one_line(e)
+    full = sprint(showerror, e)
+    # A Malt.RemoteException renders as "Remote exception from Malt.Worker on port N
+    # with PID M:" followed by the real cause. Return the first meaningful line so a
+    # session note shows e.g. "Package Revise not found", not the boilerplate prefix.
+    for line in split(full, '\n')
+        s = strip(line)
+        (isempty(s) || startswith(s, "Remote exception from Malt.Worker")) && continue
+        return String(s)
+    end
+    return String(strip(first(split(full, '\n'))))
+end
 
 """
     _unwrap(e) -> Exception
@@ -184,32 +195,6 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
             rethrow()
         end
 
-        # Load Revise — optional. Degrade gracefully and record a note.
-        if !_retry_without_revise
-            try
-                _remote_eval_fetch(w, :(using Revise))
-                session.revise_loaded = true
-            catch e
-                session.revise_loaded = false
-                push!(session.worker_notes,
-                    "Revise.jl not loaded ($(_one_line(e))). Hot-reload is disabled; add it with pkg(action=\"add\", packages=\"Revise\").")
-                if e isa Malt.RemoteException
-                    @warn "Could not load Revise.jl on worker" session=session.name
-                else
-                    @warn "Unexpected error loading Revise.jl on worker" session=session.name exception=(e, catch_backtrace())
-                end
-            end
-
-            # If loading Revise crashed the worker, respawn once without Revise.
-            if !worker_live(session)
-                _clear_worker_state!(session)
-                w2 = ensure_worker!(session; _retry_without_revise=true)
-                push!(session.worker_notes,
-                    "Loading Revise.jl crashed the worker; respawned without it. Hot-reload is disabled.")
-                return w2
-            end
-        end
-
         if session.project_path !== nothing
             try
                 path = session.project_path
@@ -237,6 +222,34 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
                 push!(session.worker_notes, "Workspace directory $(session.workspace_path) could not be restored; cleared.")
                 @warn "Failed to restore workspace on worker, clearing" workspace=session.workspace_path error=e
                 session.workspace_path = nothing
+            end
+        end
+
+        # Load Revise — optional. Loaded AFTER the project is activated so it resolves
+        # against the session's environment (where the user added it), not AgentREPL's
+        # own project. Degrade gracefully and record a note on failure.
+        if !_retry_without_revise
+            try
+                _remote_eval_fetch(w, :(using Revise))
+                session.revise_loaded = true
+            catch e
+                session.revise_loaded = false
+                push!(session.worker_notes,
+                    "Revise.jl not loaded ($(_one_line(e))). Hot-reload is disabled; add it with pkg(action=\"add\", packages=\"Revise\").")
+                if e isa Malt.RemoteException
+                    @warn "Could not load Revise.jl on worker" session=session.name
+                else
+                    @warn "Unexpected error loading Revise.jl on worker" session=session.name exception=(e, catch_backtrace())
+                end
+            end
+
+            # If loading Revise crashed the worker, respawn once without Revise.
+            if !worker_live(session)
+                _clear_worker_state!(session)
+                w2 = ensure_worker!(session; _retry_without_revise=true)
+                push!(session.worker_notes,
+                    "Loading Revise.jl crashed the worker; respawned without it. Hot-reload is disabled.")
+                return w2
             end
         end
 

--- a/test/test_revise.jl
+++ b/test/test_revise.jl
@@ -129,9 +129,24 @@
             @test e1 === nothing && occursin("v1", v1)
 
             write(src, "hotgreet() = \"v2\"\n")         # edit the tracked file
-            rev = AgentREPL.revise_on_worker!(session)
+            # Revise observes the change through its async file watcher
+            # (kqueue/FSEvents on macOS), so a single revise() right after the
+            # write can race the watcher. Poll until the new definition lands.
+            local rev = (success = false,)
+            local v2 = ""
+            local e2 = nothing
+            revised = false
+            for _ in 1:50
+                sleep(0.1)
+                rev = AgentREPL.revise_on_worker!(session)
+                v2, _, e2, _ = AgentREPL.capture_eval_on_worker("hotgreet()")
+                if rev.success && e2 === nothing && occursin("v2", v2)
+                    revised = true
+                    break
+                end
+            end
             @test rev.success
-            v2, _, e2, _ = AgentREPL.capture_eval_on_worker("hotgreet()")
+            @test revised
             @test e2 === nothing && occursin("v2", v2)
         end
     end

--- a/test/test_revise.jl
+++ b/test/test_revise.jl
@@ -108,6 +108,34 @@
         @test status.watched_packages isa Vector{String}
     end
 
+    @testset "Hot-reload from an activated project (end-to-end)" begin
+        # Exercises loading Revise from the session's own activated project — the path
+        # that was broken when Revise loaded before Pkg.activate. Adds Revise to a fresh
+        # temp project, then verifies an edit is picked up by revise() without a reset.
+        mktempdir() do proj
+            src = joinpath(proj, "Hotmod.jl")
+            write(src, "hotgreet() = \"v1\"\n")
+
+            session = AgentREPL.get_current_session!()
+            AgentREPL.activate_project_on_worker!(proj)
+            padd = AgentREPL.run_pkg_action_on_worker("add", ["Revise"])
+            @test padd.error === nothing
+            AgentREPL.reset_worker!(session)          # respawn: activate proj, then load Revise from it
+            @test AgentREPL.is_revise_available(session)
+
+            inc = AgentREPL.includet_on_worker!(session, src)
+            @test inc.success
+            v1, _, e1, _ = AgentREPL.capture_eval_on_worker("hotgreet()")
+            @test e1 === nothing && occursin("v1", v1)
+
+            write(src, "hotgreet() = \"v2\"\n")         # edit the tracked file
+            rev = AgentREPL.revise_on_worker!(session)
+            @test rev.success
+            v2, _, e2, _ = AgentREPL.capture_eval_on_worker("hotgreet()")
+            @test e2 === nothing && occursin("v2", v2)
+        end
+    end
+
     @testset "Cleanup" begin
         for name in collect(keys(AgentREPL.SESSIONS.sessions))
             try; AgentREPL.destroy_session!(name); catch; end


### PR DESCRIPTION
## Summary

Dogfooding the documented develop workflow (`activate` a project → `pkg add Revise` → `revise`) showed Revise stayed **not available**, so `includet`/`revise` failed. The marquee hot-reload feature was broken for any activated project.

**Root cause:** `ensure_worker!` ran `using Revise` at spawn time, *before* `Pkg.activate`. So Revise was resolved against AgentREPL's own env (where it's only a `[extras]` test dep), not the project the user activated and added Revise to. The unit suite missed it because `Pkg.test` runs in an environment that already carries Revise, which masked the ordering.

## Changes

- **Load Revise after the project is activated** (and the workspace is `cd`'d), so it resolves against the session's environment plus the default env on `LOAD_PATH`. The no-activate path is unchanged — Revise still loads from the spawn/default env.
- **Clearer worker notes:** `_one_line` skips Malt's `Remote exception from Malt.Worker on port N…` boilerplate so the note shows the real cause (e.g. `Package Revise not found`) instead of the wrapper prefix.
- **New end-to-end test** (`test_revise.jl`): activate a temp project, `pkg add Revise`, then verify an edit is hot-reloaded by `revise()` without a reset. This path was previously untested.

## Verified

Driven against a live server: `activate` temp project → `pkg add Revise` → `revise status` shows available → `includet` → `greet()` ⇒ `"v1"` → edit file → `revise` → `greet()` ⇒ `"v2-HOT-RELOADED"`.

318 unit / 354 with `AGENTREPL_E2E=true`, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)