### PR TITLE
Clean eval errors, MCP prompts, visible worker output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ src/
   repl_client.jl         # Standalone REPL client (run via tmux subprocess, NOT included in module)
   tools.jl               # MCP tool definitions (8 tools)
   resources.jl           # MCP resources (session variables, info, project, log, sessions)
-  server.jl              # start_server function (registers tools + resources, declares capabilities)
+  prompts.jl             # MCP prompts (julia-dev-setup, julia-benchmark, julia-debug-error)
+  server.jl              # start_server function (registers tools + resources + prompts, declares capabilities)
 ```
 
 ### Syntax Highlighting
@@ -138,7 +139,11 @@ Five read-only resources (`resources.jl`) expose session state so a client can p
 - `agentrepl://session/variables` - user variables (name, type, size) in the current session
 - `agentrepl://session/info` - Julia version, project, module count, Revise status, worker pid, setup notes
 - `agentrepl://session/project` - active `Project.toml` contents and whether a `Manifest.toml` is present
-- `agentrepl://session/log` - recent audit-log entries (when `JULIA_REPL_AUDIT_DIR` is set)
+- `agentrepl://session/log` - recent out-of-band worker output (`recent_output` ring: spawn-time precompile, async prints) plus audit-log entries when `JULIA_REPL_AUDIT_DIR` is set
+
+### MCP Prompts
+
+Three prompts (`prompts.jl`) expose reusable Julia workflows as slash commands (work without the plugin). Static `MCPPrompt` templates with `{arg}`/`{?arg?…}` substitution handled by the framework: `julia-dev-setup` (arg `path`), `julia-benchmark` (arg `code`), `julia-debug-error` (args `code`, `error?`). Registered in `start_server` with `PromptCapability`.
 
 ### Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,17 @@ Alongside the tools, AgentREPL exposes the current session's state as MCP resour
 | `agentrepl://session/variables` | User-defined variables in the current session (name, type, size) |
 | `agentrepl://session/info` | Julia version, project, module count, Revise status, worker pid, setup notes |
 | `agentrepl://session/project` | The active `Project.toml` and whether a `Manifest.toml` is present |
-| `agentrepl://session/log` | Recent audit-log entries (when `JULIA_REPL_AUDIT_DIR` is set) |
+| `agentrepl://session/log` | Recent out-of-band worker output (spawn-time precompile, async prints), plus audit-log entries when `JULIA_REPL_AUDIT_DIR` is set |
+
+## Prompts
+
+AgentREPL ships a few MCP prompts — reusable Julia workflows that Claude Code surfaces as slash commands. Unlike the plugin skills, they come with the MCP server itself, so they work without the plugin:
+
+| Prompt | Argument(s) | What it does |
+|--------|-------------|--------------|
+| `julia-dev-setup` | `path` | activate → instantiate → add Revise → hot-reload develop loop |
+| `julia-benchmark` | `code` | warm-up eval, then timed/isolated measurement (BenchmarkTools if available) |
+| `julia-debug-error` | `code`, `error?` | reproduce in an isolated eval, read the stacktrace, check types, propose a fix |
 
 ## Configuration
 

--- a/src/AgentREPL.jl
+++ b/src/AgentREPL.jl
@@ -68,6 +68,7 @@ include("logging.jl")
 include("attach.jl")
 include("tools.jl")
 include("resources.jl")
+include("prompts.jl")
 include("server.jl")
 
 function __init__()

--- a/src/attach.jl
+++ b/src/attach.jl
@@ -80,7 +80,10 @@ function _start_repl_socket_server!(session::SessionState)
                                 catch e
                                     e isa OutOfMemoryError && rethrow()
                                     e isa InterruptException && rethrow()
-                                    err_str = sprint(showerror, e, catch_backtrace())
+                                    # Unwrap include_string's LoadError so the human REPL
+                                    # sees the real exception, matching the MCP eval path.
+                                    _se = e isa LoadError ? e.error : e
+                                    err_str = sprint(showerror, _se, catch_backtrace())
                                     "ERR:" * base64encode(err_str)
                                 end
 

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -53,6 +53,58 @@ function format_elapsed(elapsed::Float64)
 end
 
 """
+    strip_harness_frames(error_str::String) -> String
+
+Remove AgentREPL/Malt wrapper frames from a rendered stacktrace, leaving only the
+user's frames. User code runs through `include_string`, so the harness is a
+contiguous tail: the first frame that is `include_string` (or the boot-level
+`eval(m::Module, e::Any)` that runs it) marks the boundary — that frame and
+everything below it (`src/worker.jl`, the Malt handler) is harness. Frames above
+it are the user's and are kept (renumbered). For a bare top-level error there are
+no user frames, so only the message remains (the empty Stacktrace is dropped).
+No-op when no harness boundary is found, so unusual traces are never mangled.
+"""
+function strip_harness_frames(error_str::String)
+    lines = split(error_str, '\n')
+    st = findfirst(l -> startswith(strip(l), "Stacktrace:"), lines)
+    st === nothing && return error_str
+
+    pre = collect(lines[1:st-1])    # message lines (the "Stacktrace:" label is re-added below)
+    body = lines[st+1:end]
+
+    isframe(l) = occursin(r"^\s*\[\d+\]", l)
+    blocks = Vector{Vector{eltype(lines)}}()
+    for l in body
+        if isframe(l)
+            push!(blocks, [l])
+        elseif !isempty(blocks)
+            push!(blocks[end], l)
+        else
+            push!(pre, l)
+        end
+    end
+
+    # First harness frame: include_string, or the boot eval that invokes it.
+    isharness(block) = occursin("include_string", block[1]) ||
+                       occursin("eval(m::Module, e::Any)", block[1])
+    cut = findfirst(isharness, blocks)
+    kept = cut === nothing ? blocks : blocks[1:cut-1]
+
+    isempty(kept) && return String(rstrip(join(pre, '\n')))   # message only; drop empty Stacktrace
+
+    out = copy(pre)
+    push!(out, lines[st])           # "Stacktrace:" label
+    for (i, block) in enumerate(kept)
+        push!(out, replace(block[1], r"\[\d+\]" => "[$i]", count=1))
+        for extra in block[2:end]
+            occursin("in expression starting at", extra) && continue
+            push!(out, extra)
+        end
+    end
+    return String(join(out, '\n'))
+end
+
+"""
     truncate_stacktrace(error_str::String; max_frames::Int=5) -> String
 
 Truncate a stacktrace to the most relevant frames.
@@ -170,7 +222,9 @@ function format_result(code::String, value_str::String, output::String, error_st
 
     # Show result or error
     if error_str !== nothing
-        truncated_error = truncate_stacktrace(error_str; max_frames=max_stackframes)
+        # Drop AgentREPL/Malt harness frames first, then truncate the user frames.
+        cleaned_error = strip_harness_frames(error_str)
+        truncated_error = truncate_stacktrace(cleaned_error; max_frames=max_stackframes)
         if use_ansi
             push!(parts, style_error(truncated_error))
         else

--- a/src/prompts.jl
+++ b/src/prompts.jl
@@ -1,0 +1,55 @@
+# prompts.jl - MCP prompts: reusable Julia workflows exposed to the client.
+#
+# Claude Code surfaces these as slash commands. Unlike the plugin skills, they ship
+# with the MCP server itself, so they work even without the plugin. Each is a static
+# user-message template; the framework's get_prompt handler fills `{arg}` placeholders
+# and resolves `{?arg?…}` conditional blocks.
+
+"""
+    agentrepl_prompts() -> Vector{MCPPrompt}
+
+Build the MCP prompt templates registered in `start_server`.
+"""
+function agentrepl_prompts()
+    MCPPrompt[
+        MCPPrompt(
+            name = "julia-dev-setup",
+            description = "Set up a Julia package for interactive development with hot-reload.",
+            arguments = [PromptArgument(name = "path", description = "Path to the package or project directory", required = true)],
+            messages = [PromptMessage(content = TextContent(text =
+                "Set up the Julia project at `{path}` for interactive development:\n" *
+                "1. activate(path=\"{path}\")\n" *
+                "2. pkg(action=\"instantiate\") to install its dependencies\n" *
+                "3. pkg(action=\"add\", packages=\"Revise\") if Revise is not already a dependency\n" *
+                "4. reset() so the fresh worker loads Revise from the project\n" *
+                "5. revise(action=\"status\") to confirm hot-reload is active\n" *
+                "Then edit .jl files and call revise(action=\"revise\") to load changes without losing session state."))]
+        ),
+        MCPPrompt(
+            name = "julia-benchmark",
+            description = "Benchmark a Julia expression, accounting for compilation.",
+            arguments = [PromptArgument(name = "code", description = "The Julia expression to benchmark", required = true)],
+            messages = [PromptMessage(content = TextContent(text =
+                "Benchmark this Julia code, separating compilation from run time:\n" *
+                "```julia\n{code}\n```\n" *
+                "1. Run it once with eval to trigger compilation (ignore that first timing).\n" *
+                "2. Run it again and report the elapsed time eval shows.\n" *
+                "3. For a rigorous number, eval `using BenchmarkTools` (add it with pkg if needed) and report `@benchmark` of the expression.\n" *
+                "Use isolated=true so the benchmark leaves no variables in the session."))]
+        ),
+        MCPPrompt(
+            name = "julia-debug-error",
+            description = "Diagnose a Julia error from the REPL.",
+            arguments = [
+                PromptArgument(name = "code", description = "The code that errors", required = true),
+                PromptArgument(name = "error", description = "The error message, if you have it", required = false),
+            ],
+            messages = [PromptMessage(content = TextContent(text =
+                "Diagnose this failing Julia code:\n" *
+                "```julia\n{code}\n```\n" *
+                "{?error?The reported error was: {error}\n}" *
+                "Reproduce it with eval (use isolated=true to avoid polluting the session), read the stacktrace, " *
+                "and check the types of the inputs with eval (e.g. `typeof(x)`). Then explain the cause and propose a fix."))]
+        ),
+    ]
+end

--- a/src/resources.jl
+++ b/src/resources.jl
@@ -97,19 +97,22 @@ end
 
 _resource_log() = _resource_safe() do
     session = get_current_session!()
+    # `recent_output` always available: out-of-band worker output (spawn-time
+    # precompile, async prints) captured by the drain, even when audit is off.
+    recent = copy(session.recent_output)
     if _AUDIT_DIR[] === nothing
-        return (session = session.name, audit_enabled = false,
-                note = "Audit logging is disabled. Set JULIA_REPL_AUDIT_DIR to enable a persistent per-session log.")
+        return (session = session.name, audit_enabled = false, recent_output = recent,
+                note = "Audit logging is disabled (set JULIA_REPL_AUDIT_DIR for a persistent per-session log). 'recent_output' is recent out-of-band worker output.")
     end
     date_str = Dates.format(Dates.today(), "yyyy-mm-dd")
     path = joinpath(_AUDIT_DIR[], "$(session.name)_$(date_str).log")
     if !isfile(path)
         return (session = session.name, audit_enabled = true, path = path, tail = String[],
-                note = "No audit entries yet today.")
+                recent_output = recent, note = "No audit entries yet today.")
     end
     lines = readlines(path)
     tail = length(lines) > 200 ? lines[end-199:end] : lines
-    (session = session.name, audit_enabled = true, path = path, tail = tail)
+    (session = session.name, audit_enabled = true, path = path, tail = tail, recent_output = recent)
 end
 
 """

--- a/src/server.jl
+++ b/src/server.jl
@@ -75,15 +75,17 @@ function start_server(; project_dir::Union{String,Nothing}=nothing)
     session_tool = create_session_tool()
     revise_tool = create_revise_tool()
 
-    # Resources expose live session state (variables, info, project, log) to the client.
+    # Resources expose live session state (variables, info, project, log); prompts are
+    # reusable Julia workflows surfaced as slash commands (work without the plugin).
     resources = agentrepl_resources()
+    prompts = agentrepl_prompts()
 
-    # Declare only the capabilities we actually implement. The framework default
-    # advertises resource subscriptions and prompts we don't serve; override it so
-    # clients see an accurate picture.
+    # Declare only the capabilities we actually implement. The framework default also
+    # advertises resource subscriptions we don't serve; declare an accurate set.
     capabilities = ModelContextProtocol.Capability[
         ModelContextProtocol.ToolCapability(list_changed=false),
         ModelContextProtocol.ResourceCapability(list_changed=false, subscribe=false),
+        ModelContextProtocol.PromptCapability(list_changed=false),
     ]
 
     # Create and start the server
@@ -93,6 +95,7 @@ function start_server(; project_dir::Union{String,Nothing}=nothing)
         description = "Persistent Julia REPL for AI agents - multi-session with Revise.jl hot-reloading",
         tools = [eval_tool, reset_tool, info_tool, pkg_tool, activate_tool, log_viewer_tool, session_tool, revise_tool],
         resources = resources,
+        prompts = prompts,
         capabilities = capabilities
     )
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,6 +17,7 @@ project environment, and Revise.jl tracking state.
 - `last_used::Float64`: Last time this session was used (from `time()`)
 - `eval_timings::Vector{Float64}`: Ring buffer of recent eval durations (capped at `MAX_EVAL_TIMINGS`)
 - `worker_notes::Vector{String}`: Non-fatal setup warnings from the current worker spawn (e.g. Revise failed to load, project activation failed). Consumed (cleared) when surfaced by `eval` or `reset`; `info` peeks without clearing. Reset to empty on every (re)spawn, so notes never leak across worker generations
+- `recent_output::Vector{String}`: Ring buffer (capped at `MAX_RECENT_OUTPUT`) of the worker's out-of-band output — lines printed outside an eval's capture window (spawn-time precompile, async tasks). Surfaced via the `session/log` resource and teed to the log viewer; cleared on (re)spawn
 """
 mutable struct SessionState
     const name::String
@@ -29,15 +30,17 @@ mutable struct SessionState
     last_used::Float64
     eval_timings::Vector{Float64}
     worker_notes::Vector{String}
+    recent_output::Vector{String}
 
     function SessionState(name::String, worker::Union{Malt.Worker,Nothing}, project_path::Union{String,Nothing}, revise_loaded::Bool=false)
         isempty(name) && error("Session name must not be empty")
         now = time()
-        new(name, worker, project_path, nothing, nothing, revise_loaded, now, now, Float64[], String[])
+        new(name, worker, project_path, nothing, nothing, revise_loaded, now, now, Float64[], String[], String[])
     end
 end
 
 const MAX_EVAL_TIMINGS = 50
+const MAX_RECENT_OUTPUT = 200
 
 """
     SessionRegistry

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -95,6 +95,7 @@ function _clear_worker_state!(session::SessionState)
     session.revise_loaded = false
     empty!(session.eval_timings)
     empty!(session.worker_notes)
+    empty!(session.recent_output)
 end
 
 """
@@ -110,19 +111,21 @@ function _handle_worker_crash!(session::SessionState, e)
 end
 
 """
-    _start_output_drain!(session_name::String, w::Malt.Worker)
+    _start_output_drain!(session::SessionState, w::Malt.Worker)
 
 Drain the worker's stdout/stderr pipes so out-of-band output (async tasks,
-finalizers, background prints that fire outside an eval's capture window) cannot
-fill the pipe buffer and block the worker.
+finalizers, spawn-time precompile, background prints that fire outside an eval's
+capture window) cannot fill the pipe buffer and block the worker.
 
 The worker is spawned with `monitor_stdout=false`/`monitor_stderr=false`, so Malt
 does NOT reprint worker output onto the host's stdout — which is the MCP JSON-RPC
-transport. We route drained lines to our own stderr (safe: never the transport),
-where Claude Code collects them in the MCP server log. In-band eval output is
-captured separately by `_with_output_capture` and is unaffected.
+transport. Each drained line is routed three safe ways (never the transport): our
+own stderr (the MCP server log), the session's `recent_output` ring (surfaced via
+the `session/log` resource), and the live log viewer when one is attached. In-band
+eval output is captured separately by `_with_output_capture` and is unaffected.
 """
-function _start_output_drain!(session_name::String, w::Malt.Worker)
+function _start_output_drain!(session::SessionState, w::Malt.Worker)
+    name = session.name
     for (pipe, label) in ((w.stdout, "stdout"), (w.stderr, "stderr"))
         @async begin
             try
@@ -130,10 +133,19 @@ function _start_output_drain!(session_name::String, w::Malt.Worker)
                     eof(pipe) && break          # blocks until a byte or EOF; clean close exits
                     line = readline(pipe)
                     isempty(line) && continue
+                    tagged = "[worker:$name:$label] " * line
+                    try; println(stderr, tagged); catch; end
+                    # recent-output ring (post-hoc visibility via session/log)
                     try
-                        println(stderr, "[worker:$session_name:$label] ", line)
-                    catch
-                    end
+                        push!(session.recent_output, line)
+                        length(session.recent_output) > MAX_RECENT_OUTPUT && popfirst!(session.recent_output)
+                    catch; end
+                    # live log viewer, if attached (e.g. watch precompile progress)
+                    try
+                        if LOG_VIEWER.log_io !== nothing
+                            println(LOG_VIEWER.log_io, tagged); flush(LOG_VIEWER.log_io)
+                        end
+                    catch; end
                 end
             catch e
                 # A clean EOF leaves the loop above; reaching here means an unexpected
@@ -141,7 +153,7 @@ function _start_output_drain!(session_name::String, w::Malt.Worker)
                 # silently dead drain is what lets the pipe fill and wedge the worker.
                 if Malt.isrunning(w)
                     try
-                        println(stderr, "[worker:$session_name:$label] drain stopped on error: ", sprint(showerror, e))
+                        println(stderr, "[worker:$name:$label] drain stopped on error: ", sprint(showerror, e))
                     catch
                     end
                 end
@@ -183,7 +195,7 @@ function ensure_worker!(session::SessionState; _retry_without_revise::Bool=false
             error("Failed to spawn worker for session '$(session.name)': $(sprint(showerror, e))")
         end
         session.worker = w
-        _start_output_drain!(session.name, w)
+        _start_output_drain!(session, w)
 
         # Load Pkg — required. A failure here means the worker is unusable.
         try
@@ -376,7 +388,15 @@ function capture_eval_on_worker(code::String; timeout::Union{Float64,Nothing}=no
                 combined_output *= "\n[stderr]\n" * stderr_content
             end
 
-            error_str = _eval_err === nothing ? nothing : sprint(showerror, _eval_err, _eval_bt)
+            # include_string wraps the user's error in a LoadError; unwrap it so the
+            # rendered message is the real exception (e.g. "UndefVarError: …"), not
+            # "LoadError: …". The backtrace still carries the user frames.
+            error_str = if _eval_err === nothing
+                nothing
+            else
+                _show_err = _eval_err isa LoadError ? _eval_err.error : _eval_err
+                sprint(showerror, _show_err, _eval_bt)
+            end
             value_str = try
                 if _use_color
                     sprint(io -> show(IOContext(io, :color => true, :compact => true, :limit => true), MIME"text/plain"(), _eval_value))

--- a/test/test_eval.jl
+++ b/test/test_eval.jl
@@ -212,6 +212,53 @@ Stacktrace:
         @test contains(result_all, "frame5")
         @test !contains(result_all, "truncated")
     end
+
+    @testset "Harness frame stripping" begin
+        wrapped = """
+boom
+Stacktrace:
+  [1] error(s::String)
+    @ Base ./error.jl:44
+  [2] g()
+    @ Main ./julia_eval:1
+  [3] top-level scope
+    @ julia_eval:1
+  [4] eval(m::Module, e::Any)
+    @ Core ./boot.jl:489
+  [5] include_string(m::Module, txt::String, fname::String)
+    @ Base ./loading.jl:2884
+  [6] top-level scope
+    @ ~/Research/AgentREPL.jl/src/worker.jl:365
+  [7] handle()
+    @ Malt ~/.julia/packages/Malt/x/src/worker.jl:120
+in expression starting at julia_eval:1
+"""
+        stripped = AgentREPL.strip_harness_frames(wrapped)
+        @test contains(stripped, "error(s::String)")
+        @test contains(stripped, "g()")
+        @test !contains(stripped, "worker.jl")
+        @test !contains(stripped, "include_string")
+        @test !contains(stripped, "boot.jl")
+        @test !contains(stripped, "Malt")
+        @test !contains(stripped, "in expression starting at")
+        @test contains(stripped, "[3] top-level scope")  # kept user frames renumbered 1..3
+        @test !contains(stripped, "[4]")
+
+        # No julia_eval/interactive_repl frame → no-op (protects the truncation tests).
+        plain = "UndefVarError: x\nStacktrace:\n [1] frame1()\n   @ Main ./file.jl:1"
+        @test AgentREPL.strip_harness_frames(plain) == plain
+        @test AgentREPL.strip_harness_frames("just a message") == "just a message"
+    end
+
+    @testset "End-to-end clean error" begin
+        _, _, err, _ = AgentREPL.capture_eval_on_worker("qqq_undefined_zzz")
+        fmt = AgentREPL.format_result("qqq_undefined_zzz", "nothing", "", err; max_stackframes=10)
+        @test contains(fmt, "UndefVarError")
+        @test !contains(fmt, "LoadError")
+        @test !contains(fmt, "worker.jl")
+        @test !contains(fmt, "include_string")
+        @test !contains(fmt, "boot.jl")
+    end
 end
 
 @testset "Worker Info" begin

--- a/test/test_mcp_protocol.jl
+++ b/test/test_mcp_protocol.jl
@@ -184,11 +184,11 @@ end
             @test resp["result"]["serverInfo"]["name"] == "julia-repl"
             @test haskey(resp["result"], "protocolVersion")
 
-            # Advertise only what we implement: tools + resources, not prompts (B1)
+            # Advertise what we implement: tools, resources, prompts (not subscribe).
             caps = resp["result"]["capabilities"]
             @test haskey(caps, "tools")
             @test haskey(caps, "resources")
-            @test !haskey(caps, "prompts")
+            @test haskey(caps, "prompts")
 
             # Send initialized notification
             send_notification!(client, "notifications/initialized")
@@ -321,6 +321,25 @@ end
             payload = JSON3.read(contents[1]["text"], Dict{String,Any})
             @test haskey(payload, "julia_version")
             @test haskey(payload, "worker_pid")
+        end
+
+        # --- prompts ---
+        @testset "prompts - list" begin
+            id = send_request!(client, "prompts/list", Dict())
+            resp = recv_response(client; timeout=30.0, id=id)
+            names = Set([p["name"] for p in resp["result"]["prompts"]])
+            @test "julia-dev-setup" in names
+            @test "julia-benchmark" in names
+            @test "julia-debug-error" in names
+        end
+
+        @testset "prompts - get substitutes args" begin
+            id = send_request!(client, "prompts/get",
+                Dict("name" => "julia-dev-setup", "arguments" => Dict("path" => "/tmp/myproj")))
+            resp = recv_response(client; timeout=30.0, id=id)
+            text = resp["result"]["messages"][1]["content"]["text"]
+            @test occursin("/tmp/myproj", text)        # {path} substituted
+            @test !occursin("{path}", text)
         end
 
         # --- transport stays clean JSON even when a worker prints out of band ---

--- a/test/test_resources.jl
+++ b/test/test_resources.jl
@@ -108,6 +108,33 @@ end
         end
     end
 
+    @testset "log resource surfaces recent_output (out-of-band worker output)" begin
+        _reset_sessions!()
+        s = A.get_current_session!()
+        empty!(s.recent_output)
+        push!(s.recent_output, "Precompiling MyPkg...")
+        push!(s.recent_output, "  ✓ MyPkg")
+        got = A._resource_log()
+        @test got.ok
+        @test haskey(got, :recent_output)
+        @test any(l -> occursin("Precompiling", l), got.recent_output)
+    end
+
+    @testset "recent_output captures an async worker print" begin
+        _reset_sessions!()
+        s = A.get_current_session!()
+        A.ensure_worker!(s)
+        empty!(s.recent_output)
+        # marker built from bytes so it can't appear in the echoed source
+        A.capture_eval_on_worker("@async (sleep(0.3); println(String(UInt8[68,82,65,73,78,75])))")  # "DRAINK"
+        captured = false
+        for _ in 1:30
+            any(l -> occursin("DRAINK", l), s.recent_output) && (captured = true; break)
+            sleep(0.1)
+        end
+        @test captured
+    end
+
     @testset "agentrepl_resources registers the five resources" begin
         rs = A.agentrepl_resources()
         uris = Set(string(r.uri) for r in rs)


### PR DESCRIPTION
Three first-class-REPL improvements surfaced while dogfooding. **Stacked on #14** (the Revise fix) since it touches `worker.jl` too — base retargets to `main` once #14 merges.

## 1. Clean eval errors
`include_string` wrapped errors in `LoadError` and the backtrace tail was AgentREPL/Malt scaffolding (`include_string`@loading.jl, `src/worker.jl`, `eval`@boot.jl, the Malt handler). Now:
- The worker (and the attach REPL) unwrap the `LoadError`, so the message is the real exception.
- `strip_harness_frames` drops the harness tail — the first `include_string`/boot-`eval(m::Module, e::Any)` frame and everything below it — keeping only the user's frames (a bare top-level error becomes message-only). Runs before the existing `max_stackframes` truncation.

`sqrt(-1)` now reads `DomainError with -1.0: …` + `throw_complex_domainerror → sqrt → sqrt(Int64) → top-level @ julia_eval` — no harness frames. A bare `UndefVarError` is just the message.

## 2. MCP prompts
`julia-dev-setup`, `julia-benchmark`, `julia-debug-error` — static templates with `{arg}`/`{?arg?…}` substitution, surfaced as slash commands. They ship with the server, so they work without the plugin. `PromptCapability` is now declared.

## 3. Visible out-of-band worker output (progress, part 1)
`SessionState` gains a `recent_output` ring; the output drain tees worker lines that land outside an eval's capture window (spawn-time precompile, async prints) to it and to the live log viewer — never the stdout transport. `agentrepl://session/log` surfaces it even when audit logging is off. (Spec-correct MCP `notifications/progress` is the follow-up fork work.)

## Tests
`strip_harness_frames` + end-to-end clean-error; `prompts/list` + `prompts/get` arg-substitution E2E (capabilities now include `prompts`); `recent_output` unit + async-capture. **318 unit / 379 with `AGENTREPL_E2E=true`**, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)